### PR TITLE
Handle lines which do not match regex

### DIFF
--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -33,12 +33,24 @@ namespace RegexColumnizer
 			if (Regex != null)
 			{
 				var m = Regex.Match(line.FullLine);
-				for (int i = m.Groups.Count - 1; i > 0; i--)
+				
+				if (m.Success)
 				{
-					logLine.ColumnValues[i-1] = new Column
+					for (int i = m.Groups.Count - 1; i > 0; i--)
+					{
+						logLine.ColumnValues[i-1] = new Column
+						{
+							Parent = logLine,
+							FullValue = m.Groups[i].Value
+						};
+					}
+				}
+				else
+				{
+					logLine.ColumnValues[columns.Length - 1] = new Column
 					{
 						Parent = logLine,
-						FullValue = m.Groups[i].Value
+						FullValue = line.FullLine
 					};
 				}
 			}


### PR DESCRIPTION
If a line fails the Regex, don't just omit it - stick it in the last column.

I picked last column because I have many log files which have the last column being the "text" field, and the "text" sometimes contains newlines. I imagine I'm not the only one with this issue :)