### PR TITLE
Apply updated regex on closing dialogue box

### DIFF
--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -93,6 +93,8 @@ namespace RegexColumnizer
 				{
 					xml.Serialize(w, d.Config);
 				}
+
+		                Init(d.Config);
 			}
 		}
 


### PR DESCRIPTION
Previously, updating the regex required restarting LogExpert in order to re-read the updated XML file. 
Configure() should update the active configuration after it has validated it.