### PR TITLE
Avoid duplicate loading of colors

### DIFF
--- a/src/LogExpert/Dialogs/HilightDialog.Designer.cs
+++ b/src/LogExpert/Dialogs/HilightDialog.Designer.cs
@@ -353,25 +353,6 @@
             this.foregroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.foregroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.foregroundColorBox.FormattingEnabled = true;
-            this.foregroundColorBox.Items.AddRange(new object[] {
-            System.Drawing.Color.Black,
-            System.Drawing.Color.Black,
-            System.Drawing.Color.White,
-            System.Drawing.Color.Gray,
-            System.Drawing.Color.DarkGray,
-            System.Drawing.Color.Blue,
-            System.Drawing.Color.LightBlue,
-            System.Drawing.Color.DarkBlue,
-            System.Drawing.Color.Green,
-            System.Drawing.Color.LightGreen,
-            System.Drawing.Color.DarkGreen,
-            System.Drawing.Color.Olive,
-            System.Drawing.Color.Red,
-            System.Drawing.Color.Pink,
-            System.Drawing.Color.Purple,
-            System.Drawing.Color.IndianRed,
-            System.Drawing.Color.DarkCyan,
-            System.Drawing.Color.Yellow});
             this.foregroundColorBox.Location = new System.Drawing.Point(5, 41);
             this.foregroundColorBox.Name = "foregroundColorBox";
             this.foregroundColorBox.Size = new System.Drawing.Size(121, 21);
@@ -386,25 +367,6 @@
             this.backgroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.backgroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.backgroundColorBox.FormattingEnabled = true;
-            this.backgroundColorBox.Items.AddRange(new object[] {
-            System.Drawing.Color.Black,
-            System.Drawing.Color.Black,
-            System.Drawing.Color.White,
-            System.Drawing.Color.Gray,
-            System.Drawing.Color.DarkGray,
-            System.Drawing.Color.Blue,
-            System.Drawing.Color.LightBlue,
-            System.Drawing.Color.DarkBlue,
-            System.Drawing.Color.Green,
-            System.Drawing.Color.LightGreen,
-            System.Drawing.Color.DarkGreen,
-            System.Drawing.Color.Olive,
-            System.Drawing.Color.Red,
-            System.Drawing.Color.Pink,
-            System.Drawing.Color.Purple,
-            System.Drawing.Color.IndianRed,
-            System.Drawing.Color.DarkCyan,
-            System.Drawing.Color.Yellow});
             this.backgroundColorBox.Location = new System.Drawing.Point(6, 91);
             this.backgroundColorBox.Name = "backgroundColorBox";
             this.backgroundColorBox.Size = new System.Drawing.Size(121, 21);


### PR DESCRIPTION
The designer file was changed a *lot* in 30c6de5a129c65e0c29ff70033109aeb1c420f98 . Part of this added code to load colors, but the colors are already loaded in `ColorComboBox`'s constructor. So you end up with 36 entries for each color combo box instead of 18. 

(By the way, I'm assuming we should base PRs against the `Development` branch?)