### PR TITLE
Set correct combobox index for known colors

### DIFF
--- a/src/LogExpert/Dialogs/HilightDialog.cs
+++ b/src/LogExpert/Dialogs/HilightDialog.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-//using System.Linq;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -203,10 +203,20 @@ namespace LogExpert.Dialogs
             if (entry != null)
             {
                 searchStringTextBox.Text = entry.SearchText;
+
                 foregroundColorBox.CustomColor = entry.ForegroundColor;
                 backgroundColorBox.CustomColor = entry.BackgroundColor;
-                foregroundColorBox.SelectedItem = entry.ForegroundColor;
-                backgroundColorBox.SelectedItem = entry.BackgroundColor;
+
+                if (foregroundColorBox.Items.Contains(entry.ForegroundColor))
+                    foregroundColorBox.SelectedIndex = foregroundColorBox.Items.Cast<Color>().ToList().LastIndexOf(entry.ForegroundColor);
+                else
+                    foregroundColorBox.SelectedItem = entry.ForegroundColor;
+
+                if (foregroundColorBox.Items.Contains(entry.ForegroundColor))
+                    backgroundColorBox.SelectedIndex = backgroundColorBox.Items.Cast<Color>().ToList().LastIndexOf(entry.BackgroundColor);
+                else
+                    backgroundColorBox.SelectedItem = entry.BackgroundColor;
+
                 regexCheckBox.Checked = entry.IsRegEx;
                 caseSensitiveCheckBox.Checked = entry.IsCaseSensitive;
                 ledCheckBox.Checked = entry.IsLedSwitch;


### PR DESCRIPTION
Known colors currently show as "Custom", because when setting .SelectedItem, the first entry (index 0) is a match.

This PR changes it so that if a known color is in the last, the last item is used, else the old behaviour continues.

Old behaviour:
![image](https://user-images.githubusercontent.com/145854/54679943-3eb3aa80-4b11-11e9-9d1d-cee3fb5b1fa8.png)

New behaviour:
![image](https://user-images.githubusercontent.com/145854/54679961-4b380300-4b11-11e9-95fb-3c9baa1c4848.png)
