### PR TITLE
Column context menu was not working

### DIFF
--- a/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
@@ -867,10 +867,14 @@ namespace LogExpert
         private void dataGridView_CellContextMenuStripNeeded(object sender,
             DataGridViewCellContextMenuStripNeededEventArgs e)
         {
-            if (e.RowIndex > 0 && e.RowIndex < dataGridView.RowCount
+            if (e.RowIndex >= 0 && e.RowIndex < dataGridView.RowCount
                                && !dataGridView.Rows[e.RowIndex].Selected)
             {
                 SelectLine(e.RowIndex, false, true);
+            }
+            else if (e.RowIndex < 0)
+            {
+                e.ContextMenuStrip = columnContextMenuStrip;
             }
 
             if (e.ContextMenuStrip == columnContextMenuStrip)


### PR DESCRIPTION
I was unable to hide a column because the context menu for the gridview header seems to be overridden by the context menu for the grid cells. Please have a look at my PR.