### PR TITLE
Check for an empty dir variable added

### DIFF
--- a/src/LogExpert/Classes/Persister/Persister.cs
+++ b/src/LogExpert/Classes/Persister/Persister.cs
@@ -165,7 +165,7 @@ namespace LogExpert
                     file = dir + Path.DirectorySeparatorChar + BuildSessionFileNameFromPath(logFileName);
                     break;
             }
-            if (!Directory.Exists(dir))
+            if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
             {
                 try
                 {


### PR DESCRIPTION
If the preferences.sessionSaveDirectory variable isn't set, then there is on every open and close action of LogExpert an error message thrown that a dir path cannot be empty. Therefore, it should be checked whether the variable is empty.