### PR TITLE
Fix file order selection when using multi-file because it is not guaranteed by OS

### DIFF
--- a/src/LogExpert/Controls/LogTabWindow/LogTabWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogTabWindow/LogTabWindowPrivate.cs
@@ -407,6 +407,8 @@ namespace LogExpert
 
         private void LoadFiles(string[] names, bool invertLogic)
         {
+            Array.Sort(names);
+
             if (names.Length == 1)
             {
                 if (names[0].EndsWith(".lxj"))


### PR DESCRIPTION
@zarunbal 

According to https://stackoverflow.com/a/38319967/1987788, it is not possible to get the actual selection order, so it was causing wrong log ordering in some cases.

The implementation simply sort the selected files by name.