### PR TITLE
Import new highlight settings (instead of replace) (close #179)

### DIFF
--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
 using NLog;
+using System.Linq;
 
 namespace LogExpert
 {
@@ -390,22 +391,34 @@ namespace LogExpert
 
             if ((flags & ExportImportFlags.ColumnizerMasks) == ExportImportFlags.ColumnizerMasks)
             {
-                newSettings.preferences.columnizerMaskList = importSettings.preferences.columnizerMaskList;
+                newSettings.preferences.columnizerMaskList = ReplaceOrKeepExisting(flags, ownSettings.preferences.columnizerMaskList, importSettings.preferences.columnizerMaskList);
             }
             if ((flags & ExportImportFlags.HighlightMasks) == ExportImportFlags.HighlightMasks)
             {
-                newSettings.preferences.highlightMaskList = importSettings.preferences.highlightMaskList;
+                newSettings.preferences.highlightMaskList = ReplaceOrKeepExisting(flags, ownSettings.preferences.highlightMaskList, importSettings.preferences.highlightMaskList);
             }
             if ((flags & ExportImportFlags.HighlightSettings) == ExportImportFlags.HighlightSettings)
             {
-                newSettings.hilightGroupList = importSettings.hilightGroupList;
+               newSettings.hilightGroupList = ReplaceOrKeepExisting(flags, ownSettings.hilightGroupList, importSettings.hilightGroupList);
             }
             if ((flags & ExportImportFlags.ToolEntries) == ExportImportFlags.ToolEntries)
             {
-                newSettings.preferences.toolEntries = importSettings.preferences.toolEntries;
+                newSettings.preferences.toolEntries = ReplaceOrKeepExisting(flags, ownSettings.preferences.toolEntries, importSettings.preferences.toolEntries);
             }
 
             return newSettings;
+        }
+
+        private static List<T> ReplaceOrKeepExisting<T>(ExportImportFlags flags, List<T> existingList, List<T> newList)
+        {
+            if ((flags & ExportImportFlags.KeepExisting) == ExportImportFlags.KeepExisting)
+            {
+                return existingList.Union(newList).ToList();                
+            }
+            else
+            {
+                return newList;
+            }
         }
 
         #endregion

--- a/src/LogExpert/Config/ExportImportFlags.cs
+++ b/src/LogExpert/Config/ExportImportFlags.cs
@@ -11,6 +11,8 @@ namespace LogExpert
         HighlightMasks = 4,
         ToolEntries = 8,
         Other = 16,
-        All = HighlightSettings | ColumnizerMasks | HighlightMasks | ToolEntries | Other
+        KeepExisting = 32,
+        All = HighlightSettings | ColumnizerMasks | HighlightMasks | ToolEntries | Other,
+        AllKeepExisting = All | KeepExisting 
     }
 }

--- a/src/LogExpert/Dialogs/HilightDialog.Designer.cs
+++ b/src/LogExpert/Dialogs/HilightDialog.Designer.cs
@@ -52,8 +52,6 @@
             this.noBackgroundCheckBox = new System.Windows.Forms.CheckBox();
             this.boldCheckBox = new System.Windows.Forms.CheckBox();
             this.wordMatchCheckBox = new System.Windows.Forms.CheckBox();
-            this.foregroundColorBox = new LogExpert.Dialogs.ColorComboBox();
-            this.backgroundColorBox = new LogExpert.Dialogs.ColorComboBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.bookmarkCommentButton = new System.Windows.Forms.Button();
             this.pluginButton = new System.Windows.Forms.Button();
@@ -70,6 +68,9 @@
             this.newGroupButton = new System.Windows.Forms.Button();
             this.groupComboBox = new System.Windows.Forms.ComboBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.importGroupButton = new System.Windows.Forms.Button();
+            this.foregroundColorBox = new LogExpert.Dialogs.ColorComboBox();
+            this.backgroundColorBox = new LogExpert.Dialogs.ColorComboBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -78,21 +79,21 @@
             // 
             // hilightListBox
             // 
-            this.hilightListBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.hilightListBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.hilightListBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.hilightListBox.FormattingEnabled = true;
             this.hilightListBox.Location = new System.Drawing.Point(21, 104);
             this.hilightListBox.Name = "hilightListBox";
-            this.hilightListBox.Size = new System.Drawing.Size(293, 173);
+            this.hilightListBox.Size = new System.Drawing.Size(424, 173);
             this.hilightListBox.TabIndex = 0;
             this.hilightListBox.SelectedIndexChanged += new System.EventHandler(this.hilightListBox_SelectedIndexChanged);
             // 
             // addButton
             // 
             this.addButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.addButton.Location = new System.Drawing.Point(320, 142);
+            this.addButton.Location = new System.Drawing.Point(451, 142);
             this.addButton.Name = "addButton";
             this.addButton.Size = new System.Drawing.Size(92, 23);
             this.addButton.TabIndex = 1;
@@ -104,7 +105,7 @@
             // deleteButton
             // 
             this.deleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.deleteButton.Location = new System.Drawing.Point(320, 171);
+            this.deleteButton.Location = new System.Drawing.Point(451, 171);
             this.deleteButton.Name = "deleteButton";
             this.deleteButton.Size = new System.Drawing.Size(92, 23);
             this.deleteButton.TabIndex = 2;
@@ -116,7 +117,7 @@
             // moveUpButton
             // 
             this.moveUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.moveUpButton.Location = new System.Drawing.Point(320, 104);
+            this.moveUpButton.Location = new System.Drawing.Point(451, 104);
             this.moveUpButton.Name = "moveUpButton";
             this.moveUpButton.Size = new System.Drawing.Size(45, 23);
             this.moveUpButton.TabIndex = 3;
@@ -128,7 +129,7 @@
             // moveDownButton
             // 
             this.moveDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.moveDownButton.Location = new System.Drawing.Point(367, 104);
+            this.moveDownButton.Location = new System.Drawing.Point(498, 104);
             this.moveDownButton.Name = "moveDownButton";
             this.moveDownButton.Size = new System.Drawing.Size(45, 23);
             this.moveDownButton.TabIndex = 4;
@@ -159,7 +160,7 @@
             // 
             this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(266, 552);
+            this.okButton.Location = new System.Drawing.Point(397, 552);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 9;
@@ -171,7 +172,7 @@
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(351, 552);
+            this.cancelButton.Location = new System.Drawing.Point(482, 552);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 10;
@@ -180,11 +181,11 @@
             // 
             // searchStringTextBox
             // 
-            this.searchStringTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.searchStringTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.searchStringTextBox.Location = new System.Drawing.Point(6, 36);
             this.searchStringTextBox.Name = "searchStringTextBox";
-            this.searchStringTextBox.Size = new System.Drawing.Size(394, 20);
+            this.searchStringTextBox.Size = new System.Drawing.Size(525, 20);
             this.searchStringTextBox.TabIndex = 11;
             this.searchStringTextBox.TextChanged += new System.EventHandler(this.ChangeToDirty);
             // 
@@ -203,7 +204,7 @@
             this.applyButton.Enabled = false;
             this.applyButton.Image = global::LogExpert.Properties.Resources.AdvancedIcon2;
             this.applyButton.ImageAlign = System.Drawing.ContentAlignment.BottomRight;
-            this.applyButton.Location = new System.Drawing.Point(320, 200);
+            this.applyButton.Location = new System.Drawing.Point(451, 200);
             this.applyButton.Name = "applyButton";
             this.applyButton.Size = new System.Drawing.Size(92, 23);
             this.applyButton.TabIndex = 13;
@@ -215,7 +216,7 @@
             // customForeColorButton
             // 
             this.customForeColorButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.customForeColorButton.Location = new System.Drawing.Point(132, 39);
+            this.customForeColorButton.Location = new System.Drawing.Point(263, 39);
             this.customForeColorButton.Name = "customForeColorButton";
             this.customForeColorButton.Size = new System.Drawing.Size(52, 23);
             this.customForeColorButton.TabIndex = 14;
@@ -227,7 +228,7 @@
             // customBackColorButton
             // 
             this.customBackColorButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.customBackColorButton.Location = new System.Drawing.Point(132, 89);
+            this.customBackColorButton.Location = new System.Drawing.Point(263, 89);
             this.customBackColorButton.Name = "customBackColorButton";
             this.customBackColorButton.Size = new System.Drawing.Size(52, 23);
             this.customBackColorButton.TabIndex = 15;
@@ -275,7 +276,7 @@
             // 
             // groupBox1
             // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.searchStringTextBox);
             this.groupBox1.Controls.Add(this.label3);
@@ -283,14 +284,14 @@
             this.groupBox1.Controls.Add(this.caseSensitiveCheckBox);
             this.groupBox1.Location = new System.Drawing.Point(12, 295);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(414, 88);
+            this.groupBox1.Size = new System.Drawing.Size(545, 88);
             this.groupBox1.TabIndex = 19;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Line match criteria";
             // 
             // groupBox2
             // 
-            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox2.Controls.Add(this.noBackgroundCheckBox);
             this.groupBox2.Controls.Add(this.boldCheckBox);
@@ -303,7 +304,7 @@
             this.groupBox2.Controls.Add(this.backgroundColorBox);
             this.groupBox2.Location = new System.Drawing.Point(12, 389);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(200, 186);
+            this.groupBox2.Size = new System.Drawing.Size(331, 186);
             this.groupBox2.TabIndex = 20;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Coloring";
@@ -345,34 +346,6 @@
             this.wordMatchCheckBox.UseVisualStyleBackColor = true;
             this.wordMatchCheckBox.CheckedChanged += new System.EventHandler(this.wordMatchCheckBox_CheckedChanged);
             // 
-            // foregroundColorBox
-            // 
-            this.foregroundColorBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.foregroundColorBox.CustomColor = System.Drawing.Color.Black;
-            this.foregroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.foregroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.foregroundColorBox.FormattingEnabled = true;
-            this.foregroundColorBox.Location = new System.Drawing.Point(5, 41);
-            this.foregroundColorBox.Name = "foregroundColorBox";
-            this.foregroundColorBox.Size = new System.Drawing.Size(121, 21);
-            this.foregroundColorBox.TabIndex = 5;
-            this.foregroundColorBox.SelectedIndexChanged += new System.EventHandler(this.ChangeToDirty);
-            // 
-            // backgroundColorBox
-            // 
-            this.backgroundColorBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.backgroundColorBox.CustomColor = System.Drawing.Color.Black;
-            this.backgroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.backgroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.backgroundColorBox.FormattingEnabled = true;
-            this.backgroundColorBox.Location = new System.Drawing.Point(6, 91);
-            this.backgroundColorBox.Name = "backgroundColorBox";
-            this.backgroundColorBox.Size = new System.Drawing.Size(121, 21);
-            this.backgroundColorBox.TabIndex = 7;
-            this.backgroundColorBox.SelectedIndexChanged += new System.EventHandler(this.ChangeToDirty);
-            // 
             // groupBox3
             // 
             this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -382,7 +355,7 @@
             this.groupBox3.Controls.Add(this.stopTailCheckBox);
             this.groupBox3.Controls.Add(this.bookmarkCheckBox);
             this.groupBox3.Controls.Add(this.ledCheckBox);
-            this.groupBox3.Location = new System.Drawing.Point(218, 389);
+            this.groupBox3.Location = new System.Drawing.Point(349, 389);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(208, 127);
             this.groupBox3.TabIndex = 21;
@@ -454,8 +427,9 @@
             // 
             // groupBox4
             // 
-            this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox4.Controls.Add(this.importGroupButton);
             this.groupBox4.Controls.Add(this.groupDownButton);
             this.groupBox4.Controls.Add(this.groupUpButton);
             this.groupBox4.Controls.Add(this.label4);
@@ -465,7 +439,7 @@
             this.groupBox4.Controls.Add(this.groupComboBox);
             this.groupBox4.Location = new System.Drawing.Point(12, 3);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(414, 84);
+            this.groupBox4.Size = new System.Drawing.Size(545, 84);
             this.groupBox4.TabIndex = 22;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Groups";
@@ -473,7 +447,7 @@
             // groupDownButton
             // 
             this.groupDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupDownButton.Location = new System.Drawing.Point(355, 49);
+            this.groupDownButton.Location = new System.Drawing.Point(486, 49);
             this.groupDownButton.Name = "groupDownButton";
             this.groupDownButton.Size = new System.Drawing.Size(45, 23);
             this.groupDownButton.TabIndex = 6;
@@ -485,7 +459,7 @@
             // groupUpButton
             // 
             this.groupUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupUpButton.Location = new System.Drawing.Point(308, 49);
+            this.groupUpButton.Location = new System.Drawing.Point(439, 49);
             this.groupUpButton.Name = "groupUpButton";
             this.groupUpButton.Size = new System.Drawing.Size(45, 23);
             this.groupUpButton.TabIndex = 5;
@@ -506,7 +480,7 @@
             // copyGroupButton
             // 
             this.copyGroupButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.copyGroupButton.Location = new System.Drawing.Point(355, 19);
+            this.copyGroupButton.Location = new System.Drawing.Point(486, 19);
             this.copyGroupButton.Name = "copyGroupButton";
             this.copyGroupButton.Size = new System.Drawing.Size(45, 23);
             this.copyGroupButton.TabIndex = 3;
@@ -518,7 +492,7 @@
             // delGroupButton
             // 
             this.delGroupButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.delGroupButton.Location = new System.Drawing.Point(308, 19);
+            this.delGroupButton.Location = new System.Drawing.Point(439, 19);
             this.delGroupButton.Name = "delGroupButton";
             this.delGroupButton.Size = new System.Drawing.Size(45, 23);
             this.delGroupButton.TabIndex = 2;
@@ -530,7 +504,7 @@
             // newGroupButton
             // 
             this.newGroupButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.newGroupButton.Location = new System.Drawing.Point(264, 19);
+            this.newGroupButton.Location = new System.Drawing.Point(395, 19);
             this.newGroupButton.Name = "newGroupButton";
             this.newGroupButton.Size = new System.Drawing.Size(42, 23);
             this.newGroupButton.TabIndex = 1;
@@ -541,13 +515,13 @@
             // 
             // groupComboBox
             // 
-            this.groupComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.groupComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupComboBox.DisplayMember = "GroupName";
             this.groupComboBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.groupComboBox.Location = new System.Drawing.Point(9, 21);
             this.groupComboBox.Name = "groupComboBox";
-            this.groupComboBox.Size = new System.Drawing.Size(238, 21);
+            this.groupComboBox.Size = new System.Drawing.Size(322, 21);
             this.groupComboBox.TabIndex = 0;
             this.toolTip1.SetToolTip(this.groupComboBox, "Choose a group to create different highlight settings. Type in a name to change i" +
         "n the name of a group.");
@@ -555,13 +529,91 @@
             this.groupComboBox.SelectionChangeCommitted += new System.EventHandler(this.groupComboBox_SelectionChangeCommitted);
             this.groupComboBox.TextUpdate += new System.EventHandler(this.groupComboBox_TextUpdate);
             // 
+            // importGroupButton
+            // 
+            this.importGroupButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.importGroupButton.Location = new System.Drawing.Point(344, 19);
+            this.importGroupButton.Name = "importGroupButton";
+            this.importGroupButton.Size = new System.Drawing.Size(45, 23);
+            this.importGroupButton.TabIndex = 7;
+            this.importGroupButton.Text = "Import";
+            this.toolTip1.SetToolTip(this.importGroupButton, "Import highlight groups");
+            this.importGroupButton.UseVisualStyleBackColor = true;
+            this.importGroupButton.Click += new System.EventHandler(this.importGroupButton_Click);
+            // 
+            // foregroundColorBox
+            // 
+            this.foregroundColorBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.foregroundColorBox.CustomColor = System.Drawing.Color.Black;
+            this.foregroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.foregroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.foregroundColorBox.FormattingEnabled = true;
+            this.foregroundColorBox.Items.AddRange(new object[] {
+            System.Drawing.Color.Black,
+            System.Drawing.Color.Black,
+            System.Drawing.Color.White,
+            System.Drawing.Color.Gray,
+            System.Drawing.Color.DarkGray,
+            System.Drawing.Color.Blue,
+            System.Drawing.Color.LightBlue,
+            System.Drawing.Color.DarkBlue,
+            System.Drawing.Color.Green,
+            System.Drawing.Color.LightGreen,
+            System.Drawing.Color.DarkGreen,
+            System.Drawing.Color.Olive,
+            System.Drawing.Color.Red,
+            System.Drawing.Color.Pink,
+            System.Drawing.Color.Purple,
+            System.Drawing.Color.IndianRed,
+            System.Drawing.Color.DarkCyan,
+            System.Drawing.Color.Yellow});
+            this.foregroundColorBox.Location = new System.Drawing.Point(5, 41);
+            this.foregroundColorBox.Name = "foregroundColorBox";
+            this.foregroundColorBox.Size = new System.Drawing.Size(252, 21);
+            this.foregroundColorBox.TabIndex = 5;
+            this.foregroundColorBox.SelectedIndexChanged += new System.EventHandler(this.ChangeToDirty);
+            // 
+            // backgroundColorBox
+            // 
+            this.backgroundColorBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.backgroundColorBox.CustomColor = System.Drawing.Color.Black;
+            this.backgroundColorBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.backgroundColorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.backgroundColorBox.FormattingEnabled = true;
+            this.backgroundColorBox.Items.AddRange(new object[] {
+            System.Drawing.Color.Black,
+            System.Drawing.Color.Black,
+            System.Drawing.Color.White,
+            System.Drawing.Color.Gray,
+            System.Drawing.Color.DarkGray,
+            System.Drawing.Color.Blue,
+            System.Drawing.Color.LightBlue,
+            System.Drawing.Color.DarkBlue,
+            System.Drawing.Color.Green,
+            System.Drawing.Color.LightGreen,
+            System.Drawing.Color.DarkGreen,
+            System.Drawing.Color.Olive,
+            System.Drawing.Color.Red,
+            System.Drawing.Color.Pink,
+            System.Drawing.Color.Purple,
+            System.Drawing.Color.IndianRed,
+            System.Drawing.Color.DarkCyan,
+            System.Drawing.Color.Yellow});
+            this.backgroundColorBox.Location = new System.Drawing.Point(6, 91);
+            this.backgroundColorBox.Name = "backgroundColorBox";
+            this.backgroundColorBox.Size = new System.Drawing.Size(252, 21);
+            this.backgroundColorBox.TabIndex = 7;
+            this.backgroundColorBox.SelectedIndexChanged += new System.EventHandler(this.ChangeToDirty);
+            // 
             // HilightDialog
             // 
             this.AcceptButton = this.okButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(439, 593);
+            this.ClientSize = new System.Drawing.Size(570, 593);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
@@ -641,5 +693,6 @@
         private System.Windows.Forms.CheckBox wordMatchCheckBox;
         private System.Windows.Forms.CheckBox boldCheckBox;
         private System.Windows.Forms.CheckBox noBackgroundCheckBox;
+        private System.Windows.Forms.Button importGroupButton;
     }
 }

--- a/src/LogExpert/Dialogs/ImportSettingsDialog.Designer.cs
+++ b/src/LogExpert/Dialogs/ImportSettingsDialog.Designer.cs
@@ -33,6 +33,7 @@
             this.textBoxFileName = new System.Windows.Forms.TextBox();
             this.labelSettingsFileToImport = new System.Windows.Forms.Label();
             this.groupBoxImportOptions = new System.Windows.Forms.GroupBox();
+            this.checkBoxKeepExistingSettings = new System.Windows.Forms.CheckBox();
             this.checkBoxOther = new System.Windows.Forms.CheckBox();
             this.checkBoxExternalTools = new System.Windows.Forms.CheckBox();
             this.checkBoxColumnizerFileMasks = new System.Windows.Forms.CheckBox();
@@ -71,6 +72,7 @@
             // 
             // groupBoxImportOptions
             // 
+            this.groupBoxImportOptions.Controls.Add(this.checkBoxKeepExistingSettings);
             this.groupBoxImportOptions.Controls.Add(this.checkBoxOther);
             this.groupBoxImportOptions.Controls.Add(this.checkBoxExternalTools);
             this.groupBoxImportOptions.Controls.Add(this.checkBoxColumnizerFileMasks);
@@ -83,9 +85,22 @@
             this.groupBoxImportOptions.TabStop = false;
             this.groupBoxImportOptions.Text = "Import options";
             // 
+            // checkBoxKeepExistingSettings
+            // 
+            this.checkBoxKeepExistingSettings.AutoSize = true;
+            this.checkBoxKeepExistingSettings.Location = new System.Drawing.Point(141, 20);
+            this.checkBoxKeepExistingSettings.Name = "checkBoxKeepExistingSettings";
+            this.checkBoxKeepExistingSettings.Size = new System.Drawing.Size(128, 17);
+            this.checkBoxKeepExistingSettings.TabIndex = 1;
+            this.checkBoxKeepExistingSettings.Tag = "32";
+            this.checkBoxKeepExistingSettings.Text = "Keep existing settings";
+            this.checkBoxKeepExistingSettings.UseVisualStyleBackColor = true;
+            // 
             // checkBoxOther
             // 
             this.checkBoxOther.AutoSize = true;
+            this.checkBoxOther.Checked = true;
+            this.checkBoxOther.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxOther.Location = new System.Drawing.Point(7, 112);
             this.checkBoxOther.Name = "checkBoxOther";
             this.checkBoxOther.Size = new System.Drawing.Size(52, 17);
@@ -97,6 +112,8 @@
             // checkBoxExternalTools
             // 
             this.checkBoxExternalTools.AutoSize = true;
+            this.checkBoxExternalTools.Checked = true;
+            this.checkBoxExternalTools.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxExternalTools.Location = new System.Drawing.Point(7, 89);
             this.checkBoxExternalTools.Name = "checkBoxExternalTools";
             this.checkBoxExternalTools.Size = new System.Drawing.Size(89, 17);
@@ -108,6 +125,8 @@
             // checkBoxColumnizerFileMasks
             // 
             this.checkBoxColumnizerFileMasks.AutoSize = true;
+            this.checkBoxColumnizerFileMasks.Checked = true;
+            this.checkBoxColumnizerFileMasks.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxColumnizerFileMasks.Location = new System.Drawing.Point(7, 66);
             this.checkBoxColumnizerFileMasks.Name = "checkBoxColumnizerFileMasks";
             this.checkBoxColumnizerFileMasks.Size = new System.Drawing.Size(126, 17);
@@ -119,6 +138,8 @@
             // checkBoxHighlightFileMasks
             // 
             this.checkBoxHighlightFileMasks.AutoSize = true;
+            this.checkBoxHighlightFileMasks.Checked = true;
+            this.checkBoxHighlightFileMasks.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxHighlightFileMasks.Location = new System.Drawing.Point(7, 43);
             this.checkBoxHighlightFileMasks.Name = "checkBoxHighlightFileMasks";
             this.checkBoxHighlightFileMasks.Size = new System.Drawing.Size(116, 17);
@@ -130,6 +151,8 @@
             // checkBoxHighlightSettings
             // 
             this.checkBoxHighlightSettings.AutoSize = true;
+            this.checkBoxHighlightSettings.Checked = true;
+            this.checkBoxHighlightSettings.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxHighlightSettings.Location = new System.Drawing.Point(7, 20);
             this.checkBoxHighlightSettings.Name = "checkBoxHighlightSettings";
             this.checkBoxHighlightSettings.Size = new System.Drawing.Size(106, 17);
@@ -192,13 +215,14 @@
     private System.Windows.Forms.Button buttonFile;
     private System.Windows.Forms.TextBox textBoxFileName;
     private System.Windows.Forms.Label labelSettingsFileToImport;
-    private System.Windows.Forms.GroupBox groupBoxImportOptions;
     private System.Windows.Forms.Button buttonOk;
     private System.Windows.Forms.Button buttonCancel;
-    private System.Windows.Forms.CheckBox checkBoxExternalTools;
-    private System.Windows.Forms.CheckBox checkBoxColumnizerFileMasks;
-    private System.Windows.Forms.CheckBox checkBoxHighlightFileMasks;
-    private System.Windows.Forms.CheckBox checkBoxHighlightSettings;
-    private System.Windows.Forms.CheckBox checkBoxOther;
-  }
+        public System.Windows.Forms.CheckBox checkBoxExternalTools;
+        public System.Windows.Forms.CheckBox checkBoxColumnizerFileMasks;
+        public System.Windows.Forms.CheckBox checkBoxHighlightFileMasks;
+        public System.Windows.Forms.CheckBox checkBoxHighlightSettings;
+        public System.Windows.Forms.CheckBox checkBoxOther;
+        public System.Windows.Forms.CheckBox checkBoxKeepExistingSettings;
+        public System.Windows.Forms.GroupBox groupBoxImportOptions;
+    }
 }

--- a/src/LogExpert/Dialogs/ImportSettingsDialog.cs
+++ b/src/LogExpert/Dialogs/ImportSettingsDialog.cs
@@ -30,13 +30,6 @@ namespace LogExpert.Dialogs
 
         private void ImportSettingsDialog_Load(object sender, EventArgs e)
         {
-            foreach (Control ctl in groupBoxImportOptions.Controls)
-            {
-                if (ctl.Tag != null)
-                {
-                    ((CheckBox)ctl).Checked = true;
-                }
-            }
         }
 
         private void fileButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
@zarunbal I've included the feature to import settings with the option to keep existing ones. It is ready to work with all current settings based on lists (Highlight, file masks and external tools) , but as the original issue states, it's specially useful for highlight settings, which now can be shared and imported in different environments without affecting existing settings.

![logexpert2](https://user-images.githubusercontent.com/4236481/109091074-df924380-76f2-11eb-8d55-e6a0490cc806.gif)
