### PR TITLE
Prevent ArgumentOutOfRangeException when navigating through Multifiles (close #202)

### DIFF
--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -1706,6 +1706,12 @@ namespace LogExpert
                     return;
                 }
 
+                // Prevent ArgumentOutOfRangeException
+                else if (line >= dataGridView.Rows.Count)
+                {
+                    line = dataGridView.Rows.Count - 1;
+                }
+
                 dataGridView.Rows[line].Selected = true;
 
                 if (shouldScroll)
@@ -1713,6 +1719,10 @@ namespace LogExpert
                     dataGridView.CurrentCell = dataGridView.Rows[line].Cells[0];
                     dataGridView.Focus();
                 }
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                _logger.Error(e, "Error while selecting line: ");
             }
             catch (IndexOutOfRangeException e)
             {


### PR DESCRIPTION
Preventing `ArgumentOutOfRangeException` when navigating through Multifiles, caused in the case when the newest file "in line" is empty (no loglines in it).