### PR TITLE
Add PortableMode for Session Files

### DIFF
--- a/src/LogExpert/Classes/Persister/Persister.cs
+++ b/src/LogExpert/Classes/Persister/Persister.cs
@@ -147,28 +147,42 @@ namespace LogExpert.Classes.Persister
 
         private static string BuildPersisterFileName(string logFileName, Preferences preferences)
         {
-            string dir = null;
-            string file = null;
+            string dir;
+            string file;
+
             switch (preferences.saveLocation)
             {
                 case SessionSaveLocation.SameDir:
                 default:
+                {
                     FileInfo fileInfo = new FileInfo(logFileName);
                     dir = fileInfo.DirectoryName;
                     file = fileInfo.DirectoryName + Path.DirectorySeparatorChar + fileInfo.Name + ".lxp";
                     break;
+                }
                 case SessionSaveLocation.DocumentsDir:
+                {
                     dir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) +
                           Path.DirectorySeparatorChar +
                           "LogExpert";
                     file = dir + Path.DirectorySeparatorChar + BuildSessionFileNameFromPath(logFileName);
                     break;
+                }
                 case SessionSaveLocation.OwnDir:
+                {
                     dir = preferences.sessionSaveDirectory;
                     file = dir + Path.DirectorySeparatorChar + BuildSessionFileNameFromPath(logFileName);
                     break;
+                }
+                case SessionSaveLocation.ApplicationStartupDir:
+                {
+                    dir = Application.StartupPath;
+                    file = dir + Path.DirectorySeparatorChar + BuildSessionFileNameFromPath(logFileName);
+                    break;
+                }
             }
-            if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+
+            if (string.IsNullOrWhiteSpace(dir) == false && Directory.Exists(dir) == false)
             {
                 try
                 {

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -60,9 +60,12 @@ namespace LogExpert.Config
             }
         }
         
-        public static string ConfigDir => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\LogExpert";
+        public static string ConfigDir => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "LogExpert";
 
-        public static string PortableMode => Application.StartupPath + "\\portableMode.json";
+        /// <summary>
+        /// Application.StartupPath + portableMode.json
+        /// </summary>
+        public static string PortableMode => Application.StartupPath + Path.DirectorySeparatorChar + "portableMode.json";
 
         public static Settings Settings => Instance._settings;
 
@@ -112,14 +115,14 @@ namespace LogExpert.Config
                 Directory.CreateDirectory(dir);
             }
 
-            if (!File.Exists(dir + "\\settings.json"))
+            if (!File.Exists(dir + Path.DirectorySeparatorChar + "settings.json"))
             {
                 return LoadOrCreateNew(null);
             }
 
             try
             {
-                FileInfo fileInfo = new FileInfo(dir + "\\settings.json");
+                FileInfo fileInfo = new FileInfo(dir + Path.DirectorySeparatorChar + "settings.json");
                 return LoadOrCreateNew(fileInfo);
             }
             catch (Exception e)
@@ -298,7 +301,7 @@ namespace LogExpert.Config
                         Directory.CreateDirectory(dir);
                     }
 
-                    FileInfo fileInfo = new FileInfo(dir + "\\settings.json");
+                    FileInfo fileInfo = new FileInfo(dir + Path.DirectorySeparatorChar + "settings.json");
                     Save(fileInfo, settings);
                 }
 

--- a/src/LogExpert/Config/SessionSaveLocation.cs
+++ b/src/LogExpert/Config/SessionSaveLocation.cs
@@ -5,9 +5,22 @@ namespace LogExpert.Config
     [Serializable]
     public enum SessionSaveLocation
     {
+        //Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + Path.DirectorySeparatorChar + "LogExpert"
+        /// <summary>
+        /// <see cref="Environment.SpecialFolder.MyDocuments"/>
+        /// </summary>
         DocumentsDir,
+        //same directory as the logfile
         SameDir,
+        //uses configured folder to save the session files 
+        /// <summary>
+        /// <see cref="Preferences.sessionSaveDirectory"/>
+        /// </summary>
         OwnDir,
+        /// <summary>
+        /// <see cref="System.Windows.Forms.Application.StartupPath"/>
+        /// </summary>
+        ApplicationStartupDir,
         LoadedSessionFile
     }
 }

--- a/src/LogExpert/Dialogs/SettingsDialog.Designer.cs
+++ b/src/LogExpert/Dialogs/SettingsDialog.Designer.cs
@@ -121,14 +121,15 @@
             this.panelPlugin = new System.Windows.Forms.Panel();
             this.buttonConfigPlugin = new System.Windows.Forms.Button();
             this.tabPageSessions = new System.Windows.Forms.TabPage();
+            this.checkBoxPortableMode = new System.Windows.Forms.CheckBox();
             this.checkBoxSaveFilter = new System.Windows.Forms.CheckBox();
             this.groupBoxPersistantFileLocation = new System.Windows.Forms.GroupBox();
-            this.checkBoxPortableMode = new System.Windows.Forms.CheckBox();
             this.labelSessionSaveOwnDir = new System.Windows.Forms.Label();
             this.buttonSessionSaveDir = new System.Windows.Forms.Button();
             this.radioButtonSessionSaveOwn = new System.Windows.Forms.RadioButton();
             this.radioButtonsessionSaveDocuments = new System.Windows.Forms.RadioButton();
             this.radioButtonSessionSameDir = new System.Windows.Forms.RadioButton();
+            this.radioButtonSessionApplicationStartupDir = new System.Windows.Forms.RadioButton();
             this.checkBoxSaveSessions = new System.Windows.Forms.CheckBox();
             this.tabPageMemory = new System.Windows.Forms.TabPage();
             this.groupBoxCPUAndStuff = new System.Windows.Forms.GroupBox();
@@ -150,7 +151,6 @@
             this.buttonImport = new System.Windows.Forms.Button();
             this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.radioButtonSessionApplicationStartupDir = new System.Windows.Forms.RadioButton();
             this.tabControlSettings.SuspendLayout();
             this.tabPageViewSettings.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.upDownMaximumFilterEntriesDisplayed)).BeginInit();
@@ -1303,6 +1303,20 @@
             this.tabPageSessions.Text = "Persistence";
             this.tabPageSessions.UseVisualStyleBackColor = true;
             // 
+            // checkBoxPortableMode
+            // 
+            this.checkBoxPortableMode.AutoSize = true;
+            this.checkBoxPortableMode.Location = new System.Drawing.Point(34, 377);
+            this.checkBoxPortableMode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.checkBoxPortableMode.Name = "checkBoxPortableMode";
+            this.checkBoxPortableMode.Size = new System.Drawing.Size(199, 24);
+            this.checkBoxPortableMode.TabIndex = 3;
+            this.checkBoxPortableMode.Text = "Activate Portable Mode";
+            this.toolTip.SetToolTip(this.checkBoxPortableMode, "If this mode is activated, the save file will be loaded from the Executable Locat" +
+        "ion");
+            this.checkBoxPortableMode.UseVisualStyleBackColor = true;
+            this.checkBoxPortableMode.CheckedChanged += new System.EventHandler(this.OnPortableModeCheckedChanged);
+            // 
             // checkBoxSaveFilter
             // 
             this.checkBoxSaveFilter.AutoSize = true;
@@ -1330,20 +1344,6 @@
             this.groupBoxPersistantFileLocation.TabIndex = 1;
             this.groupBoxPersistantFileLocation.TabStop = false;
             this.groupBoxPersistantFileLocation.Text = "Persistence file location";
-            // 
-            // checkBoxPortableMode
-            // 
-            this.checkBoxPortableMode.AutoSize = true;
-            this.checkBoxPortableMode.Location = new System.Drawing.Point(34, 377);
-            this.checkBoxPortableMode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.checkBoxPortableMode.Name = "checkBoxPortableMode";
-            this.checkBoxPortableMode.Size = new System.Drawing.Size(199, 24);
-            this.checkBoxPortableMode.TabIndex = 3;
-            this.checkBoxPortableMode.Text = "Activate Portable Mode";
-            this.toolTip.SetToolTip(this.checkBoxPortableMode, "If this mode is activated, the save file will be loaded from the Executable Locat" +
-        "ion");
-            this.checkBoxPortableMode.UseVisualStyleBackColor = true;
-            this.checkBoxPortableMode.CheckedChanged += new System.EventHandler(this.OnPortableModeCheckedChanged);
             // 
             // labelSessionSaveOwnDir
             // 
@@ -1400,6 +1400,19 @@
             this.radioButtonSessionSameDir.TabStop = true;
             this.radioButtonSessionSameDir.Text = "Same directory as log file";
             this.radioButtonSessionSameDir.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonSessionApplicationStartupDir
+            // 
+            this.radioButtonSessionApplicationStartupDir.AutoSize = true;
+            this.radioButtonSessionApplicationStartupDir.Location = new System.Drawing.Point(8, 177);
+            this.radioButtonSessionApplicationStartupDir.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radioButtonSessionApplicationStartupDir.Name = "radioButtonSessionApplicationStartupDir";
+            this.radioButtonSessionApplicationStartupDir.Size = new System.Drawing.Size(230, 24);
+            this.radioButtonSessionApplicationStartupDir.TabIndex = 5;
+            this.radioButtonSessionApplicationStartupDir.TabStop = true;
+            this.radioButtonSessionApplicationStartupDir.Text = "Application startup directory";
+            this.toolTip.SetToolTip(this.radioButtonSessionApplicationStartupDir, "This path is based on the executable and where it has been started from.");
+            this.radioButtonSessionApplicationStartupDir.UseVisualStyleBackColor = true;
             // 
             // checkBoxSaveSessions
             // 
@@ -1652,18 +1665,6 @@
             this.dataGridViewTextBoxColumn2.MinimumWidth = 40;
             this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
             this.dataGridViewTextBoxColumn2.Width = 259;
-            // 
-            // radioButtonSessionApplicationStartupDir
-            // 
-            this.radioButtonSessionApplicationStartupDir.AutoSize = true;
-            this.radioButtonSessionApplicationStartupDir.Location = new System.Drawing.Point(8, 177);
-            this.radioButtonSessionApplicationStartupDir.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.radioButtonSessionApplicationStartupDir.Name = "radioButtonSessionApplicationStartupDir";
-            this.radioButtonSessionApplicationStartupDir.Size = new System.Drawing.Size(210, 24);
-            this.radioButtonSessionApplicationStartupDir.TabIndex = 5;
-            this.radioButtonSessionApplicationStartupDir.TabStop = true;
-            this.radioButtonSessionApplicationStartupDir.Text = "Same directory as log file";
-            this.radioButtonSessionApplicationStartupDir.UseVisualStyleBackColor = true;
             // 
             // SettingsDialog
             // 

--- a/src/LogExpert/Dialogs/SettingsDialog.Designer.cs
+++ b/src/LogExpert/Dialogs/SettingsDialog.Designer.cs
@@ -150,6 +150,7 @@
             this.buttonImport = new System.Windows.Forms.Button();
             this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.radioButtonSessionApplicationStartupDir = new System.Windows.Forms.RadioButton();
             this.tabControlSettings.SuspendLayout();
             this.tabPageViewSettings.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.upDownMaximumFilterEntriesDisplayed)).BeginInit();
@@ -399,9 +400,9 @@
             this.checkBoxSingleInstance.Location = new System.Drawing.Point(9, 66);
             this.checkBoxSingleInstance.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.checkBoxSingleInstance.Name = "checkBoxSingleInstance";
-            this.checkBoxSingleInstance.Size = new System.Drawing.Size(173, 24);
+            this.checkBoxSingleInstance.Size = new System.Drawing.Size(183, 24);
             this.checkBoxSingleInstance.TabIndex = 1;
-            this.checkBoxSingleInstance.Text = "Allow only 1 window";
+            this.checkBoxSingleInstance.Text = "Allow only 1 Instance";
             this.checkBoxSingleInstance.UseVisualStyleBackColor = true;
             // 
             // checkBoxAskCloseTabs
@@ -1289,6 +1290,7 @@
             // 
             // tabPageSessions
             // 
+            this.tabPageSessions.Controls.Add(this.checkBoxPortableMode);
             this.tabPageSessions.Controls.Add(this.checkBoxSaveFilter);
             this.tabPageSessions.Controls.Add(this.groupBoxPersistantFileLocation);
             this.tabPageSessions.Controls.Add(this.checkBoxSaveSessions);
@@ -1314,12 +1316,12 @@
             // 
             // groupBoxPersistantFileLocation
             // 
-            this.groupBoxPersistantFileLocation.Controls.Add(this.checkBoxPortableMode);
             this.groupBoxPersistantFileLocation.Controls.Add(this.labelSessionSaveOwnDir);
             this.groupBoxPersistantFileLocation.Controls.Add(this.buttonSessionSaveDir);
             this.groupBoxPersistantFileLocation.Controls.Add(this.radioButtonSessionSaveOwn);
             this.groupBoxPersistantFileLocation.Controls.Add(this.radioButtonsessionSaveDocuments);
             this.groupBoxPersistantFileLocation.Controls.Add(this.radioButtonSessionSameDir);
+            this.groupBoxPersistantFileLocation.Controls.Add(this.radioButtonSessionApplicationStartupDir);
             this.groupBoxPersistantFileLocation.Location = new System.Drawing.Point(34, 134);
             this.groupBoxPersistantFileLocation.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBoxPersistantFileLocation.Name = "groupBoxPersistantFileLocation";
@@ -1332,7 +1334,7 @@
             // checkBoxPortableMode
             // 
             this.checkBoxPortableMode.AutoSize = true;
-            this.checkBoxPortableMode.Location = new System.Drawing.Point(10, 172);
+            this.checkBoxPortableMode.Location = new System.Drawing.Point(34, 377);
             this.checkBoxPortableMode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.checkBoxPortableMode.Name = "checkBoxPortableMode";
             this.checkBoxPortableMode.Size = new System.Drawing.Size(199, 24);
@@ -1609,7 +1611,7 @@
             this.buttonOk.TabIndex = 0;
             this.buttonOk.Text = "OK";
             this.buttonOk.UseVisualStyleBackColor = true;
-            this.buttonOk.Click += new System.EventHandler(this.okButton_Click);
+            this.buttonOk.Click += new System.EventHandler(this.OnOkButtonClick);
             // 
             // helpProvider
             // 
@@ -1650,6 +1652,18 @@
             this.dataGridViewTextBoxColumn2.MinimumWidth = 40;
             this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
             this.dataGridViewTextBoxColumn2.Width = 259;
+            // 
+            // radioButtonSessionApplicationStartupDir
+            // 
+            this.radioButtonSessionApplicationStartupDir.AutoSize = true;
+            this.radioButtonSessionApplicationStartupDir.Location = new System.Drawing.Point(8, 177);
+            this.radioButtonSessionApplicationStartupDir.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radioButtonSessionApplicationStartupDir.Name = "radioButtonSessionApplicationStartupDir";
+            this.radioButtonSessionApplicationStartupDir.Size = new System.Drawing.Size(210, 24);
+            this.radioButtonSessionApplicationStartupDir.TabIndex = 5;
+            this.radioButtonSessionApplicationStartupDir.TabStop = true;
+            this.radioButtonSessionApplicationStartupDir.Text = "Same directory as log file";
+            this.radioButtonSessionApplicationStartupDir.UseVisualStyleBackColor = true;
             // 
             // SettingsDialog
             // 
@@ -1851,5 +1865,6 @@
         private System.Windows.Forms.Label labelMaximumFilterEntriesDisplayed;
         private System.Windows.Forms.CheckBox checkBoxAutoPick;
         private System.Windows.Forms.CheckBox checkBoxPortableMode;
+        private System.Windows.Forms.RadioButton radioButtonSessionApplicationStartupDir;
     }
 }

--- a/src/LogExpert/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert/Dialogs/SettingsDialog.cs
@@ -103,6 +103,7 @@ namespace LogExpert.Dialogs
 
             checkBoxTimeSpread.Checked = Preferences.showTimeSpread;
             checkBoxReverseAlpha.Checked = Preferences.reverseAlpha;
+
             radioButtonTimeView.Checked = Preferences.timeSpreadTimeMode;
             radioButtonLineView.Checked = !Preferences.timeSpreadTimeMode;
 
@@ -123,8 +124,19 @@ namespace LogExpert.Dialogs
                 case SessionSaveLocation.DocumentsDir:
                 {
                     radioButtonsessionSaveDocuments.Checked = true;
+                    break;
                 }
-                break;
+                case SessionSaveLocation.ApplicationStartupDir:
+                {
+                    radioButtonSessionApplicationStartupDir.Checked = true;
+                    break;
+                }
+            }
+            
+            //overwrite preferences save location in portable mode to always be application startup directory
+            if (checkBoxPortableMode.Checked)
+            {
+                radioButtonSessionApplicationStartupDir.Checked = true;
             }
 
             upDownMaximumFilterEntriesDisplayed.Value = Preferences.maximumFilterEntriesDisplayed;
@@ -582,7 +594,7 @@ namespace LogExpert.Dialogs
             DisplayFontName();
         }
 
-        private void okButton_Click(object sender, EventArgs e)
+        private void OnOkButtonClick(object sender, EventArgs e)
         {
             Preferences.timestampControl = checkBoxTimestamp.Checked;
             Preferences.filterSync = checkBoxSyncFilter.Checked;
@@ -626,6 +638,10 @@ namespace LogExpert.Dialogs
             else if (radioButtonSessionSaveOwn.Checked)
             {
                 Preferences.saveLocation = SessionSaveLocation.OwnDir;
+            }
+            else if (radioButtonSessionApplicationStartupDir.Checked)
+            {
+                Preferences.saveLocation = SessionSaveLocation.ApplicationStartupDir;
             }
             else
             {
@@ -775,14 +791,24 @@ namespace LogExpert.Dialogs
                 {
                     case CheckState.Checked when !File.Exists(ConfigManager.PortableMode):
                     {
-                        File.Create(ConfigManager.PortableMode);
-                        break;
+                        using (File.Create(ConfigManager.PortableMode)) 
+                            break;
                     }
                     case CheckState.Unchecked when File.Exists(ConfigManager.PortableMode):
                     {
                         File.Delete(ConfigManager.PortableMode);
                         break;
                     }
+                }
+
+                switch (checkBoxPortableMode.CheckState)
+                {
+                    case CheckState.Unchecked:
+                        checkBoxPortableMode.Text = @"Activate Portable Mode";
+                        break;
+                    case CheckState.Checked:
+                        checkBoxPortableMode.Text = @"Deactivate Portable Mode";
+                        break;
                 }
             }
             catch (Exception exception)

--- a/src/LogExpert/Dialogs/SettingsDialog.resx
+++ b/src/LogExpert/Dialogs/SettingsDialog.resx
@@ -126,6 +126,18 @@
   <metadata name="columnColumnizer.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="columnFileMask.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="columnColumnizer.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="columnFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="columnHighlightGroup.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="columnFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -138,6 +150,12 @@
   <data name="labelNoteMultiFile.Text" xml:space="preserve">
     <value>Note: You can always load your logfiles as MultiFile automatically if the files names follow the MultiFile naming rule (&lt;filename&gt;, &lt;filename&gt;.1, &lt;filename&gt;.2, ...). Simply choose 'MultiFile' from the File menu after loading the first file.</value>
   </data>
+  <metadata name="helpProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>144, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/src/LogExpert/Dialogs/SettingsDialog.resx
+++ b/src/LogExpert/Dialogs/SettingsDialog.resx
@@ -120,6 +120,9 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>144, 17</value>
   </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>144, 17</value>
+  </metadata>
   <metadata name="columnFileMask.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -152,9 +155,6 @@
   </data>
   <metadata name="helpProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>144, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/src/LogExpert/Program.cs
+++ b/src/LogExpert/Program.cs
@@ -156,6 +156,11 @@ namespace LogExpert
                         _logger.Error(errMsg, "IpcClientChannel error, giving up: ");
                         MessageBox.Show($"Cannot open connection to first instance ({errMsg})", "LogExpert");
                     }
+
+                    if (settings.preferences.allowOnlyOneInstance)
+                    {
+                        MessageBox.Show($"Only one instance allowed, uncheck \"View Settings => Allow only 1 Instances\" to start multiple instances!", "Logexpert");
+                    }
                 }
 
                 mutex.Close();

--- a/src/UnitTests/RolloverHandlerTestBase.cs
+++ b/src/UnitTests/RolloverHandlerTestBase.cs
@@ -86,14 +86,17 @@ namespace LogExpert
         {
             int lineCount = 10;
             string fullName = dInfo == null ? fileName : dInfo.FullName + Path.DirectorySeparatorChar + fileName;
-            FileStream stream = File.Create(fullName);
-            StreamWriter writer = new StreamWriter(stream);
-            for (int i = 1; i <= lineCount; ++i)
+
+            using (StreamWriter writer = new StreamWriter(File.Create(fullName)))
             {
-                writer.WriteLine("Line number " + i.ToString("D3") + " of File " + fullName);
+                for (int i = 1; i <= lineCount; ++i)
+                {
+                    writer.WriteLine("Line number " + i.ToString("D3") + " of File " + fullName);
+                }
+
+                writer.Flush();
             }
-            writer.Flush();
-            writer.Close();
+
             return fullName;
         }
     }


### PR DESCRIPTION
This will add portable mode for persistence files.
If portable mode is activated, persistence files will be saved in the startup directory of the application.

New persistence file option added:
- Application startup Directory: this will save the persistence data for log files (.lxp) into the application startup folder

![image](https://user-images.githubusercontent.com/8225398/179229659-e3b5fbf8-6a75-42fd-9883-d318a4b5c40d.png)


this should help with https://github.com/zarunbal/LogExpert/issues/233 and https://github.com/zarunbal/LogExpert/issues/228