### PR TITLE
Plugin config for portable mode

### DIFF
--- a/src/LogExpert/Classes/Columnizer/ColumnizerPicker.cs
+++ b/src/LogExpert/Classes/Columnizer/ColumnizerPicker.cs
@@ -42,12 +42,13 @@ namespace LogExpert.Classes.Columnizer
                 return null;
             }
             ConstructorInfo cti = columnizer.GetType().GetConstructor(Type.EmptyTypes);
+
             if (cti != null)
             {
                 object o = cti.Invoke(new object[] { });
-                if (o is IColumnizerConfigurator)
+                if (o is IColumnizerConfigurator configurator)
                 {
-                    ((IColumnizerConfigurator)o).LoadConfig(ConfigManager.ConfigDir);
+                    configurator.LoadConfig(ConfigManager.Settings.preferences.PortableMode ? ConfigManager.PortableModeDir : ConfigManager.ConfigDir);
                 }
                 return (ILogLineColumnizer)o;
             }

--- a/src/LogExpert/Classes/Persister/Persister.cs
+++ b/src/LogExpert/Classes/Persister/Persister.cs
@@ -176,7 +176,7 @@ namespace LogExpert.Classes.Persister
                 }
                 case SessionSaveLocation.ApplicationStartupDir:
                 {
-                    dir = Application.StartupPath;
+                    dir = Application.StartupPath + Path.DirectorySeparatorChar + "sessionfiles";
                     file = dir + Path.DirectorySeparatorChar + BuildSessionFileNameFromPath(logFileName);
                     break;
                 }

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -63,9 +63,14 @@ namespace LogExpert.Config
         public static string ConfigDir => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "LogExpert";
 
         /// <summary>
-        /// Application.StartupPath + portableMode.json
+        /// Application.StartupPath + portable
         /// </summary>
-        public static string PortableMode => Application.StartupPath + Path.DirectorySeparatorChar + "portableMode.json";
+        public static string PortableModeDir => Application.StartupPath + Path.DirectorySeparatorChar + "portable";
+
+        /// <summary>
+        /// portableMode.json
+        /// </summary>
+        public static string PortableModeSettingsFileName => "portableMode.json";
 
         public static Settings Settings => Instance._settings;
 
@@ -99,7 +104,7 @@ namespace LogExpert.Config
 
             string dir;
 
-            if (!File.Exists(PortableMode))
+            if (File.Exists(PortableModeDir + Path.DirectorySeparatorChar + PortableModeSettingsFileName) == false)
             {
                 _logger.Info("Load settings standard mode");
                dir = ConfigDir;
@@ -294,7 +299,7 @@ namespace LogExpert.Config
                 _logger.Info("Saving settings");
                 lock (this)
                 {
-                    string dir = File.Exists(PortableMode) ? Application.StartupPath : ConfigDir;
+                    string dir = Settings.preferences.PortableMode ? Application.StartupPath : ConfigDir;
 
                     if (!Directory.Exists(dir))
                     {

--- a/src/LogExpert/Config/Preferences.cs
+++ b/src/LogExpert/Config/Preferences.cs
@@ -60,7 +60,9 @@ namespace LogExpert.Config
         public int pollingInterval = 250;
         
         public bool reverseAlpha = false;
-        
+
+        public bool PortableMode { get; set; }
+
         /// <summary>
         /// Save Directory of the last logfile
         /// </summary>
@@ -75,7 +77,7 @@ namespace LogExpert.Config
         public bool setLastColumnWidth;
         
         public bool showBubbles = true;
-        
+
         public bool showColumnFinder;
         
         public Color showTailColor = Color.FromKnownColor(KnownColor.Blue);

--- a/src/LogExpert/Dialogs/FilterSelectorForm.Designer.cs
+++ b/src/LogExpert/Dialogs/FilterSelectorForm.Designer.cs
@@ -110,7 +110,7 @@
       this.configButton.TabIndex = 7;
       this.configButton.Text = "Config...";
       this.configButton.UseVisualStyleBackColor = true;
-      this.configButton.Click += new System.EventHandler(this.configButton_Click);
+      this.configButton.Click += new System.EventHandler(this.OnConfigButtonClick);
       // 
       // FilterSelectorForm
       // 

--- a/src/LogExpert/Dialogs/FilterSelectorForm.cs
+++ b/src/LogExpert/Dialogs/FilterSelectorForm.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
 using LogExpert.Config;
-// using System.Linq;
 
 namespace LogExpert.Dialogs
 {
@@ -22,7 +21,7 @@ namespace LogExpert.Dialogs
             SelectedColumnizer = currentColumnizer;
             _callback = callback;
             InitializeComponent();
-            filterComboBox.SelectedIndexChanged += filterComboBox_SelectedIndexChanged;
+            filterComboBox.SelectedIndexChanged += OnFilterComboBoxSelectedIndexChanged;
 
             // for the currently selected columnizer use the current instance and not the template instance from
             // columnizer registry. This ensures that changes made in columnizer config dialogs
@@ -62,7 +61,7 @@ namespace LogExpert.Dialogs
 
         #region Events handler
 
-        private void filterComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        private void OnFilterComboBoxSelectedIndexChanged(object sender, EventArgs e)
         {
             ILogLineColumnizer col = _columnizerList[filterComboBox.SelectedIndex];
             SelectedColumnizer = col;
@@ -73,11 +72,18 @@ namespace LogExpert.Dialogs
         }
 
 
-        private void configButton_Click(object sender, EventArgs e)
+        private void OnConfigButtonClick(object sender, EventArgs e)
         {
-            if (SelectedColumnizer is IColumnizerConfigurator)
+            if (SelectedColumnizer is IColumnizerConfigurator configurator)
             {
-                ((IColumnizerConfigurator) SelectedColumnizer).Configure(_callback, ConfigManager.ConfigDir);
+                string configDir = ConfigManager.ConfigDir;
+
+                if (ConfigManager.Settings.preferences.PortableMode)
+                {
+                    configDir = ConfigManager.PortableModeDir;
+                }
+
+                configurator.Configure(_callback, configDir);
                 IsConfigPressed = true;
             }
         }

--- a/src/LogExpert/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert/Dialogs/SettingsDialog.cs
@@ -169,7 +169,7 @@ namespace LogExpert.Dialogs
 
         private void FillPortableMode()
         {
-            checkBoxPortableMode.CheckState = File.Exists(ConfigManager.PortableMode) ? CheckState.Checked : CheckState.Unchecked;
+            checkBoxPortableMode.CheckState = Preferences.PortableMode ? CheckState.Checked : CheckState.Unchecked;
         }
 
         private void DisplayFontName()
@@ -446,7 +446,7 @@ namespace LogExpert.Dialogs
             {
                 if (entry is ILogExpertPluginConfigurator configurator)
                 {
-                    configurator.SaveConfig(ConfigManager.ConfigDir);
+                    configurator.SaveConfig(checkBoxPortableMode.Checked ? ConfigManager.PortableModeDir : ConfigManager.ConfigDir);
                 }
             }
 
@@ -454,7 +454,7 @@ namespace LogExpert.Dialogs
             {
                 if (entry is ILogExpertPluginConfigurator configurator)
                 {
-                    configurator.SaveConfig(ConfigManager.ConfigDir);
+                    configurator.SaveConfig(checkBoxPortableMode.Checked ? ConfigManager.PortableModeDir : ConfigManager.ConfigDir);
                 }
             }
         }
@@ -789,14 +789,19 @@ namespace LogExpert.Dialogs
             {
                 switch (checkBoxPortableMode.CheckState)
                 {
-                    case CheckState.Checked when !File.Exists(ConfigManager.PortableMode):
+                    case CheckState.Checked when !File.Exists(ConfigManager.PortableModeDir + Path.DirectorySeparatorChar + ConfigManager.PortableModeSettingsFileName):
                     {
-                        using (File.Create(ConfigManager.PortableMode)) 
+                        if (Directory.Exists(ConfigManager.PortableModeDir) == false)
+                        {
+                            Directory.CreateDirectory(ConfigManager.PortableModeDir);
+                        }
+
+                        using (File.Create(ConfigManager.PortableModeDir + Path.DirectorySeparatorChar + ConfigManager.PortableModeSettingsFileName)) 
                             break;
                     }
-                    case CheckState.Unchecked when File.Exists(ConfigManager.PortableMode):
+                    case CheckState.Unchecked when File.Exists(ConfigManager.PortableModeDir + Path.DirectorySeparatorChar + ConfigManager.PortableModeSettingsFileName):
                     {
-                        File.Delete(ConfigManager.PortableMode);
+                        File.Delete(ConfigManager.PortableModeDir + Path.DirectorySeparatorChar + ConfigManager.PortableModeSettingsFileName);
                         break;
                     }
                 }
@@ -804,11 +809,18 @@ namespace LogExpert.Dialogs
                 switch (checkBoxPortableMode.CheckState)
                 {
                     case CheckState.Unchecked:
+                    {
                         checkBoxPortableMode.Text = @"Activate Portable Mode";
+                        Preferences.PortableMode = false;
                         break;
+                    }
+
                     case CheckState.Checked:
+                    {
+                        Preferences.PortableMode = true;
                         checkBoxPortableMode.Text = @"Deactivate Portable Mode";
                         break;
+                    }
                 }
             }
             catch (Exception exception)

--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -9,17 +9,6 @@ using System.Xml.Serialization;
 
 namespace RegexColumnizer
 {
-    public class RegexColumnizerConfig
-    {
-        #region Properties
-
-        public string Expression { get; set; } = "(?<text>.*)";
-
-        public string Name { get; set; }
-
-        #endregion
-    }
-
     public abstract class BaseRegexColumnizer : ILogLineColumnizer, IColumnizerConfigurator
     {
         #region Fields
@@ -32,6 +21,7 @@ namespace RegexColumnizer
         #region Properties
 
         public RegexColumnizerConfig Config { get; private set; }
+        
         public Regex Regex { get; private set; }
 
         #endregion
@@ -48,7 +38,9 @@ namespace RegexColumnizer
             return Config.Name;
         }
         public string GetDescription() => "Columns are filled by regular expression named capture groups";
+        
         public int GetColumnCount() => columns.Length;
+
         public string[] GetColumnNames() => columns;
 
         public IColumnizedLogLine SplitLine(ILogLineColumnizerCallback callback, ILogLine line)
@@ -139,7 +131,7 @@ namespace RegexColumnizer
             RegexColumnizerConfig config;
             if (!File.Exists(configFile))
             {
-                config = new RegexColumnizerConfig()
+                config = new RegexColumnizerConfig
                 {
                     Name = GetName()
                 };
@@ -159,7 +151,7 @@ namespace RegexColumnizer
         {
             var name = GetType().Name;
             string configPath = Path.Combine(configDir, name);
-            configPath = Path.ChangeExtension(configPath, "xml");
+            configPath = Path.ChangeExtension(configPath, "xml"); //todo change to json
             return configPath;
         }
 

--- a/src/RegexColumnizer/RegexColumnizer.csproj
+++ b/src/RegexColumnizer/RegexColumnizer.csproj
@@ -56,6 +56,7 @@
     </Compile>
     <Compile Include="RegexColumnizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegexColumnizerConfig.cs" />
     <Compile Include="RegexColumnizerConfigDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/RegexColumnizer/RegexColumnizerConfig.cs
+++ b/src/RegexColumnizer/RegexColumnizerConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace RegexColumnizer
+{
+    public class RegexColumnizerConfig
+    {
+        #region Properties
+
+        public string Expression { get; set; } = "(?<text>.*)";
+
+        public string Name { get; set; }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
further changes to portable mode!
portableMode configuration and plugin configuration is now saved in a subfolder "portable" in the application startup directory, this should help with separation of files.

- portableMode.json can just be moved to the new folder
- plugin configuration files, currently saved in %appdata%\logexpert, can be copied to applicationstartuppath/portable/ and are loaded from this location in portableMode
- sessionFiles in portable mode are saved in the "sessionfiles" folder in the application startup folder, again for file separation and organisation

this should now fix https://github.com/zarunbal/LogExpert/issues/233 and logexpert should now have a full portable mode, where all configuration and session data is saved in the application startup directory