### PR TITLE
Issues/issue 20 memory leak

### DIFF
--- a/src/LogExpert/Classes/PaintHelper.cs
+++ b/src/LogExpert/Classes/PaintHelper.cs
@@ -17,16 +17,13 @@ namespace LogExpert.Classes
 
         private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
-        private Color bookmarkColor = Color.FromArgb(165, 200, 225);
+        private Color _bookmarkColor = Color.FromArgb(165, 200, 225);
 
         #endregion
 
         #region Properties
 
-        private static Preferences Preferences
-        {
-            get { return ConfigManager.Settings.preferences; }
-        }
+        private static Preferences Preferences => ConfigManager.Settings.preferences;
 
         #endregion
 
@@ -43,7 +40,7 @@ namespace LogExpert.Classes
             ILogLine line = logPaintCtx.GetLogLine(rowIndex);
             if (line != null)
             {
-                HilightEntry entry = logPaintCtx.FindHilightEntry(line, true);
+                HilightEntry entry = logPaintCtx.FindHighlightEntry(line, true);
                 e.Graphics.SetClip(e.CellBounds);
                 if ((e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected)
                 {
@@ -289,18 +286,16 @@ namespace LogExpert.Classes
 
         #region Private Methods
 
-        private static void PaintCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e,
-            DataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
+        private static void PaintCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, DataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
         {
             PaintHighlightedCell(logPaintCtx, e, gridView, noBackgroundFill, groundEntry);
         }
 
 
-        private static void PaintHighlightedCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e,
-            DataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
+        private static void PaintHighlightedCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, DataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
         {
-            object value = e.Value != null ? e.Value : "";
-            IList<HilightMatchEntry> matchList = logPaintCtx.FindHilightMatches(value as ILogLine);
+            object value = e.Value ?? string.Empty;
+            IList<HilightMatchEntry> matchList = logPaintCtx.FindHighlightMatches(value as ILogLine);
             // too many entries per line seem to cause problems with the GDI 
             while (matchList.Count > 50)
             {
@@ -309,10 +304,10 @@ namespace LogExpert.Classes
 
             HilightMatchEntry hme = new HilightMatchEntry();
             hme.StartPos = 0;
-            hme.Length = (value as string).Length;
+            hme.Length = (value as string).Length; //ignore possible null reference, because object will be string.Empty if e.value was NULL
             hme.HilightEntry = new HilightEntry(value as string,
-                groundEntry != null ? groundEntry.ForegroundColor : Color.FromKnownColor(KnownColor.Black),
-                groundEntry != null ? groundEntry.BackgroundColor : Color.Empty,
+                groundEntry?.ForegroundColor ?? Color.FromKnownColor(KnownColor.Black),
+                groundEntry?.BackgroundColor ?? Color.Empty,
                 false);
             matchList = MergeHighlightMatchEntries(matchList, hme);
 
@@ -387,10 +382,7 @@ namespace LogExpert.Classes
                     foreColor, flags);
 
                 wordPos.Offset(wordSize.Width, 0);
-                if (bgBrush != null)
-                {
-                    bgBrush.Dispose();
-                }
+                bgBrush?.Dispose();
             }
         }
 
@@ -425,10 +417,10 @@ namespace LogExpert.Classes
                     {
                         entryArray[i] = me.HilightEntry;
                     }
-                    else
-                    {
-                        //entryArray[i].ForegroundColor = me.HilightEntry.ForegroundColor;
-                    }
+                    //else
+                    //{
+                    //    //entryArray[i].ForegroundColor = me.HilightEntry.ForegroundColor;
+                    //}
                 }
             }
 

--- a/src/LogExpert/Classes/PaintHelper.cs
+++ b/src/LogExpert/Classes/PaintHelper.cs
@@ -213,6 +213,7 @@ namespace LogExpert.Classes
             catch (NullReferenceException e)
             {
                 // See https://connect.microsoft.com/VisualStudio/feedback/details/366943/autoresizecolumns-in-datagridview-throws-nullreferenceexception
+                // possible solution => https://stackoverflow.com/questions/36287553/nullreferenceexception-when-trying-to-set-datagridview-column-width-brings-th
                 // There are some rare situations with null ref exceptions when resizing columns and on filter finished
                 // So catch them here. Better than crashing.
                 _logger.Error(e, "Error while resizing columns: ");

--- a/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
@@ -328,7 +328,10 @@ namespace LogExpert.Controls.LogWindow
 
         private void OnDataGridViewPaint(object sender, PaintEventArgs e)
         {
-            if (ShowBookmarkBubbles) AddBookmarkOverlays();
+            if (ShowBookmarkBubbles)
+            {
+                AddBookmarkOverlays();
+            }
         }
 
         // ======================================================================================

--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -20,7 +20,6 @@ using LogExpert.Dialogs;
 using LogExpert.Entities;
 using LogExpert.Entities.EventArgs;
 using LogExpert.Interface;
-//using System.Linq;
 
 namespace LogExpert.Controls.LogWindow
 {
@@ -1501,7 +1500,7 @@ namespace LogExpert.Controls.LogWindow
                 {
                     if (!IsMultiFile && dataGridView.SelectedRows.Count == 1)
                     {
-                        StatusLineText("");
+                        StatusLineText(string.Empty);
                     }
                 }
             }
@@ -1523,7 +1522,7 @@ namespace LogExpert.Controls.LogWindow
                         }
                     }
 
-                    if (filterGridView.Rows.Count > 0) // exception no rows
+                    if (filterGridView.Rows.GetRowCount(DataGridViewElementStates.None) > 0) // exception no rows
                     {
                         filterGridView.CurrentCell = filterGridView.Rows[index].Cells[0];
                     }
@@ -2940,9 +2939,9 @@ namespace LogExpert.Controls.LogWindow
             return new List<int>();
         }
 
-        /* ========================================================================
-       * Timestamp stuff
-       * =======================================================================*/
+       /* ========================================================================
+        * Timestamp stuff
+        * =======================================================================*/
 
         private void SetTimestampLimits()
         {

--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -327,8 +327,7 @@ namespace LogExpert.Controls.LogWindow
                 dataGridView.CurrentCell = dataGridView.Rows[_reloadMemento.currentLine].Cells[0];
             }
 
-            if (_reloadMemento.firstDisplayedLine < dataGridView.RowCount &&
-                _reloadMemento.firstDisplayedLine >= 0)
+            if (_reloadMemento.firstDisplayedLine < dataGridView.RowCount && _reloadMemento.firstDisplayedLine >= 0)
             {
                 dataGridView.FirstDisplayedScrollingRowIndex = _reloadMemento.firstDisplayedLine;
             }
@@ -656,7 +655,7 @@ namespace LogExpert.Controls.LogWindow
                     int currentLineNum = dataGridView.CurrentCellAddress.Y;
                     dataGridView.RowCount = 0;
                     dataGridView.RowCount = e.LineCount;
-                    if (!_guiStateArgs.FollowTail)
+                    if (_guiStateArgs.FollowTail == false)
                     {
                         if (currentLineNum >= dataGridView.RowCount)
                         {
@@ -672,6 +671,7 @@ namespace LogExpert.Controls.LogWindow
                 }
 
                 _logger.Debug("UpdateGrid(): new RowCount={0}", dataGridView.RowCount);
+
                 if (e.IsRollover)
                 {
                     // Multifile rollover
@@ -950,6 +950,7 @@ namespace LogExpert.Controls.LogWindow
 
             Type oldColType = _filterParams.currentColumnizer?.GetType();
             Type newColType = columnizer?.GetType();
+            
             if (oldColType != newColType && _filterParams.columnRestrict && _filterParams.isFilterTail)
             {
                 _filterParams.columnList.Clear();
@@ -1072,6 +1073,7 @@ namespace LogExpert.Controls.LogWindow
             catch (NullReferenceException e)
             {
                 // See https://connect.microsoft.com/VisualStudio/feedback/details/366943/autoresizecolumns-in-datagridview-throws-nullreferenceexception
+                // possible solution => https://stackoverflow.com/questions/36287553/nullreferenceexception-when-trying-to-set-datagridview-column-width-brings-th
                 // There are some rare situations with null ref exceptions when resizing columns and on filter finished
                 // So catch them here. Better than crashing.
                 _logger.Error(e, "Error while resizing columns: ");
@@ -1095,7 +1097,7 @@ namespace LogExpert.Controls.LogWindow
                 column = Column.EmptyColumn;
             }
 
-            IList<HilightMatchEntry> matchList = FindHilightMatches(column);
+            IList<HilightMatchEntry> matchList = FindHighlightMatches(column);
             // too many entries per line seem to cause problems with the GDI
             while (matchList.Count > 50)
             {
@@ -1263,12 +1265,12 @@ namespace LogExpert.Controls.LogWindow
 
         private HilightEntry FindHilightEntry(ITextValue line)
         {
-            return FindHilightEntry(line, false);
+            return FindHighlightEntry(line, false);
         }
 
         private HilightEntry FindFirstNoWordMatchHilightEntry(ITextValue line)
         {
-            return FindHilightEntry(line, true);
+            return FindHighlightEntry(line, true);
         }
 
         private bool CheckHighlightEntryMatch(HilightEntry entry, ITextValue column)
@@ -1706,15 +1708,15 @@ namespace LogExpert.Controls.LogWindow
 
                 if (line == -1)
                 {
-                    MessageBox.Show(this, "Not found:",
-                        "Search result"); // Hmm... is that experimental code from early days?
+                    // Hmm... is that experimental code from early days?
+                    MessageBox.Show(this, "Not found:", "Search result");
                     return;
                 }
 
                 // Prevent ArgumentOutOfRangeException
-                else if (line >= dataGridView.Rows.Count)
+                if (line >= dataGridView.Rows.GetRowCount(DataGridViewElementStates.None))
                 {
-                    line = dataGridView.Rows.Count - 1;
+                    line = dataGridView.Rows.GetRowCount(DataGridViewElementStates.None) - 1;
                 }
 
                 dataGridView.Rows[line].Selected = true;
@@ -3709,8 +3711,7 @@ namespace LogExpert.Controls.LogWindow
                 int currentLine = dataGridView.CurrentCellAddress.Y;
                 if (currentLine >= 0)
                 {
-                    dataGridView.CurrentCell =
-                        dataGridView.Rows[dataGridView.CurrentCellAddress.Y].Cells[col.Index];
+                    dataGridView.CurrentCell = dataGridView.Rows[dataGridView.CurrentCellAddress.Y].Cells[col.Index];
                 }
             }
         }

--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -1327,8 +1327,7 @@ namespace LogExpert.Controls.LogWindow
             return resultList;
         }
 
-        private void GetHighlightEntryMatches(ITextValue line, IList<HilightEntry> hilightEntryList,
-            IList<HilightMatchEntry> resultList)
+        private void GetHighlightEntryMatches(ITextValue line, IList<HilightEntry> hilightEntryList, IList<HilightMatchEntry> resultList)
         {
             foreach (HilightEntry entry in hilightEntryList)
             {

--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -921,7 +921,7 @@ namespace LogExpert.Controls.LogWindow
             // Check if the filtered columns disappeared, if so must refresh the UI
             if (_filterParams.columnRestrict)
             {
-                string[] newColumns = columnizer != null ? columnizer.GetColumnNames() : new string[0];
+                string[] newColumns = columnizer != null ? columnizer.GetColumnNames() : Array.Empty<string>();
                 bool colChanged = false;
 
                 if (dataGridView.ColumnCount - 2 == newColumns.Length) // two first columns are 'marker' and 'line number'
@@ -1674,7 +1674,7 @@ namespace LogExpert.Controls.LogWindow
                     return;
                 }
 
-                dataGridView.Invoke(new SelectLineFx((line1, triggerSyncCall) => SelectLine(line1, triggerSyncCall, true)), new object[] { line, true });
+                dataGridView.Invoke(new SelectLineFx((line1, triggerSyncCall) => SelectLine(line1, triggerSyncCall, true)), line, true);
             }
             catch (Exception ex) // in the case the windows is already destroyed
             {
@@ -2502,10 +2502,8 @@ namespace LogExpert.Controls.LogWindow
                 if (diff > 0)
                 {
                     diff -= dataGridView.RowHeadersWidth / 2;
-                    dataGridView.Columns[dataGridView.Columns.Count - 1].Width =
-                        dataGridView.Columns[dataGridView.Columns.Count - 1].Width + diff;
-                    filterGridView.Columns[filterGridView.Columns.Count - 1].Width =
-                        filterGridView.Columns[filterGridView.Columns.Count - 1].Width + diff;
+                    dataGridView.Columns[dataGridView.Columns.GetColumnCount(DataGridViewElementStates.None) - 1].Width += diff;
+                    filterGridView.Columns[filterGridView.Columns.GetColumnCount(DataGridViewElementStates.None) - 1].Width += diff;
                 }
             }
         }
@@ -2893,18 +2891,18 @@ namespace LogExpert.Controls.LogWindow
 
         private void ApplyDataGridViewPrefs(DataGridView dataGridView, Preferences prefs)
         {
-            if (dataGridView.Columns.Count > 1)
+            if (dataGridView.Columns.GetColumnCount(DataGridViewElementStates.None) > 1)
             {
                 if (prefs.setLastColumnWidth)
                 {
-                    dataGridView.Columns[dataGridView.Columns.Count - 1].MinimumWidth = prefs.lastColumnWidth;
+                    dataGridView.Columns[dataGridView.Columns.GetColumnCount(DataGridViewElementStates.None) - 1].MinimumWidth = prefs.lastColumnWidth;
                 }
                 else
                 {
                     // Workaround for a .NET bug which brings the DataGridView into an unstable state (causing lots of NullReferenceExceptions).
                     dataGridView.FirstDisplayedScrollingColumnIndex = 0;
 
-                    dataGridView.Columns[dataGridView.Columns.Count - 1].MinimumWidth = 5; // default
+                    dataGridView.Columns[dataGridView.Columns.GetColumnCount(DataGridViewElementStates.None) - 1].MinimumWidth = 5; // default
                 }
             }
 
@@ -2990,7 +2988,7 @@ namespace LogExpert.Controls.LogWindow
             {
                 foreach (int colIndex in filter.columnList)
                 {
-                    if (colIndex < dataGridView.Columns.Count - 2)
+                    if (colIndex < dataGridView.Columns.GetColumnCount(DataGridViewElementStates.None) - 2)
                     {
                         if (names.Length > 0)
                         {
@@ -3429,7 +3427,7 @@ namespace LogExpert.Controls.LogWindow
                 else
                 {
                     RowHeightEntry entry = _rowHeightList[rowNum];
-                    entry.Height = entry.Height - _lineHeight;
+                    entry.Height -= _lineHeight;
                     if (entry.Height <= _lineHeight)
                     {
                         _rowHeightList.Remove(rowNum);
@@ -3451,7 +3449,7 @@ namespace LogExpert.Controls.LogWindow
                     entry = _rowHeightList[rowNum];
                 }
 
-                entry.Height = entry.Height + _lineHeight;
+                entry.Height += _lineHeight;
             }
 
             dataGridView.UpdateRowHeightInfo(rowNum, false);
@@ -3507,7 +3505,7 @@ namespace LogExpert.Controls.LogWindow
                 bookmark = _bookmarkProvider.GetBookmarkForLine(lineNum);
             }
 
-            bookmark.Text = bookmark.Text + text;
+            bookmark.Text += text;
             dataGridView.Refresh();
             filterGridView.Refresh();
             OnBookmarkTextChanged(bookmark);

--- a/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
@@ -96,6 +96,7 @@ namespace LogExpert.Controls.LogWindow
                     _logFileReader.IsXmlMode = true;
                     _logFileReader.XmlLogConfig = xmlColumnizer.GetXmlLogConfiguration();
                 }
+
                 if (_forcedColumnizerForLoading != null)
                 {
                     CurrentColumnizer = _forcedColumnizerForLoading;
@@ -492,7 +493,7 @@ namespace LogExpert.Controls.LogWindow
         /// <param name="line"></param>
         /// <param name="noWordMatches"></param>
         /// <returns></returns>
-        public HilightEntry FindHilightEntry(ITextValue line, bool noWordMatches)
+        public HilightEntry FindHighlightEntry(ITextValue line, bool noWordMatches)
         {
             // first check the temp entries
             lock (_tempHighlightEntryListLock)
@@ -527,7 +528,7 @@ namespace LogExpert.Controls.LogWindow
             }
         }
 
-        public IList<HilightMatchEntry> FindHilightMatches(ITextValue column)
+        public IList<HilightMatchEntry> FindHighlightMatches(ITextValue column)
         {
             IList<HilightMatchEntry> resultList = new List<HilightMatchEntry>();
             if (column != null)
@@ -604,7 +605,7 @@ namespace LogExpert.Controls.LogWindow
             _progressEventArgs.Visible = true;
             SendProgressBarUpdate();
 
-            SearchFx searchFx = new SearchFx(Search);
+            SearchFx searchFx = Search;
             searchFx.BeginInvoke(searchParams, SearchComplete, null);
 
             RemoveAllSearchHighlightEntries();

--- a/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
@@ -1109,12 +1109,14 @@ namespace LogExpert.Controls.LogWindow
         {
             if (isCellMode)
             {
+                //possible performance issue, see => https://docs.microsoft.com/en-us/dotnet/desktop/winforms/controls/best-practices-for-scaling-the-windows-forms-datagridview-control?view=netframeworkdesktop-4.8#using-the-selected-cells-rows-and-columns-collections-efficiently
                 dataGridView.SelectionMode = DataGridViewSelectionMode.CellSelect;
             }
             else
             {
                 dataGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             }
+
             _guiStateArgs.CellSelectMode = isCellMode;
         }
 

--- a/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
@@ -819,7 +819,7 @@ namespace LogExpert.Controls.LogWindow
                             _logger.Debug("AddBookmarkOverlay() r.Location={0}, width={1}, scroll_offset={2}", r.Location.X, r.Width, dataGridView.HorizontalScrollingOffset);
                         }
                         overlay.Position = r.Location - new Size(dataGridView.HorizontalScrollingOffset, 0);
-                        overlay.Position = overlay.Position + new Size(10, r.Height / 2);
+                        overlay.Position += new Size(10, r.Height / 2);
                         dataGridView.AddOverlay(overlay);
                     }
                 }

--- a/src/LogExpert/Dialogs/BookmarkWindow.cs
+++ b/src/LogExpert/Dialogs/BookmarkWindow.cs
@@ -121,7 +121,7 @@ namespace LogExpert.Dialogs
         {
             if (bookmarkData.IsBookmarkAtLine(lineNum))
             {
-                if (bookmarkDataGridView.Rows.Count < bookmarkData.Bookmarks.Count)
+                if (bookmarkDataGridView.Rows.GetRowCount(DataGridViewElementStates.None) < bookmarkData.Bookmarks.Count)
                 {
                     // just for the case... There was an exception but I cannot find the cause
                     UpdateView();

--- a/src/LogExpert/Interface/ILogPaintContext.cs
+++ b/src/LogExpert/Interface/ILogPaintContext.cs
@@ -27,9 +27,9 @@ namespace LogExpert.Interface
 
         Bookmark GetBookmarkForLine(int lineNum);
 
-        HilightEntry FindHilightEntry(ITextValue line, bool noWordMatches);
+        HilightEntry FindHighlightEntry(ITextValue line, bool noWordMatches);
 
-        IList<HilightMatchEntry> FindHilightMatches(ITextValue line);
+        IList<HilightMatchEntry> FindHighlightMatches(ITextValue line);
 
         #endregion
     }


### PR DESCRIPTION
Based on https://docs.microsoft.com/en-us/dotnet/desktop/winforms/controls/best-practices-for-scaling-the-windows-forms-datagridview-control?view=netframeworkdesktop-4.8#using-the-selected-cells-rows-and-columns-collections-efficiently

Adapted GridView.Rows.Count calls, to use GetRowCount instead

This should help with #20 

- gridview.Columns.Count has been replaced with gridview.Columns.GetColumnCount
- gridview.Rows.Count has been replaced with gridview.Rows.GetRowCount

this branch needs to be tested where this memory leak happend

Possible Future Changes that need to be made:

- gridview.RowCount is an abstraction of gridview.Rows.Count and needs to be replaced with gridview.Rows.GetRowCount
- gridviewColumnCount is an abstraction of gridview.Columns.Count and needs to be replaced with gridview.Columns.GetColumnCount