### PR TITLE
Added code to the RegexColumnizer to avoid null columns & the resulting NullPointer exceptions

### DIFF
--- a/src/LogExpert.sln
+++ b/src/LogExpert.sln
@@ -58,6 +58,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "setup", "setup", "{C625E7C2
 		setup\LogExpertInstaller.iss = setup\LogExpertInstaller.iss
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegexColumnizer.UnitTests", "RegexColumnizer.UnitTests\RegexColumnizer.UnitTests.csproj", "{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -358,6 +360,24 @@ Global
 		{3D01E923-5219-488B-B0A7-98521841E680}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{3D01E923-5219-488B-B0A7-98521841E680}.Release|Win32.ActiveCfg = Release|Any CPU
 		{3D01E923-5219-488B-B0A7-98521841E680}.Release|Win32.Build.0 = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Debug|Win32.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Any CPU.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Win32.ActiveCfg = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.DebugNoTimeout|Win32.Build.0 = Debug|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Win32.ActiveCfg = Release|Any CPU
+		{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}.Release|Win32.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RegexColumnizer.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/RegexColumnizer.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RegexColumnizer.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RegexColumnizer.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("FBFB598D-B94A-4AD3-A355-0D5A618CEEE3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -44,6 +45,9 @@
           <HintPath>..\packages\Moq.4.18.4\lib\net462\Moq.dll</HintPath>
         </Reference>
         <Reference Include="mscorlib" />
+        <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+          <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
+        </Reference>
         <Reference Include="System" />
         <Reference Include="System.Configuration" />
         <Reference Include="System.Core" />
@@ -55,9 +59,6 @@
           <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
         </Reference>
         <Reference Include="System.Xml" />
-        <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-            <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-        </Reference>
     </ItemGroup>
     <ItemGroup>
         <Compile Include="RegexColumnizerTests.cs" />
@@ -73,10 +74,24 @@
         <Name>RegexColumnizer</Name>
       </ProjectReference>
     </ItemGroup>
-    <ItemGroup>
-      <None Include="packages.config" />
-    </ItemGroup>
+	<ItemGroup>
+    <PackageReference Include="Moq">
+      <Version>4.18.4</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit">
+      <Version>3.13.3</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>4.2.1</Version>
+    </PackageReference>
+  </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+      <PropertyGroup>
+        <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      </PropertyGroup>
+      <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
+    </Target>
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{FBFB598D-B94A-4AD3-A355-0D5A618CEEE3}</ProjectGuid>
+        <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>RegexColumnizer.UnitTests</RootNamespace>
+        <AssemblyName>RegexColumnizer.UnitTests</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+	<PropertyGroup>
+		<SignAssembly>true</SignAssembly>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AssemblyOriginatorKeyFile>..\Solution Items\Key.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+          <HintPath>..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
+        </Reference>
+        <Reference Include="Moq, Version=4.18.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+          <HintPath>..\packages\Moq.4.18.4\lib\net462\Moq.dll</HintPath>
+        </Reference>
+        <Reference Include="mscorlib" />
+        <Reference Include="System" />
+        <Reference Include="System.Configuration" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+          <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Xml" />
+        <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
+            <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="RegexColumnizerTests.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\ColumnizerLib\ColumnizerLib.csproj">
+        <Project>{e72c2bb1-34de-4d66-a830-9647c3837833}</Project>
+        <Name>ColumnizerLib</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\RegexColumnizer\RegexColumnizer.csproj">
+        <Project>{b5a7dfa4-48a8-4616-8008-7441699ec946}</Project>
+        <Name>RegexColumnizer</Name>
+      </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+      <None Include="packages.config" />
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+
+</Project>

--- a/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
@@ -20,7 +20,6 @@
 		<AssemblyOriginatorKeyFile>..\Solution Items\Key.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
@@ -30,7 +29,6 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
         <OutputPath>bin\Release\</OutputPath>

--- a/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizer.UnitTests.csproj
@@ -86,18 +86,4 @@
     </PackageReference>
   </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-      <PropertyGroup>
-        <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-      </PropertyGroup>
-      <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
-    </Target>
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-         Other similar extension points exist, see Microsoft.Common.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-    -->
-
 </Project>

--- a/src/RegexColumnizer.UnitTests/RegexColumnizerTests.cs
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizerTests.cs
@@ -1,0 +1,79 @@
+﻿using LogExpert;
+using Moq;
+using NUnit.Framework;
+
+namespace RegexColumnizer.UnitTests
+{
+    [TestFixture]
+    public class RegexColumnizerTests
+    {
+        [Test]
+        public void SplitLineLogRegexDoesNotMatchLine()
+        {
+            var columnizerConfig = new RegexColumnizerConfig
+            {
+                //We just need a regex that matches the line.
+                Expression = @"^(?'time'[\d]+)\s+(?'Message'.+)$",
+                Name = "Test regex"
+            };
+
+            var columnizer = new Regex1Columnizer();
+            columnizer.Init(columnizerConfig);
+            
+            var notMatchingLogLine = new TestLogLine(5, "Error in com.example.core");
+            
+            var parsedLogLine = columnizer.SplitLine(Mock.Of<ILogLineColumnizerCallback>(), notMatchingLogLine);
+            
+            // verify that the expected number of columns are created
+            Assert.AreEqual(2, parsedLogLine.ColumnValues.Length);
+
+            //verify that the entire text is in the last column
+            Assert.AreEqual("Error in com.example.core", parsedLogLine.ColumnValues[1].Text);
+            
+            // Verify that the other columns are empty strings
+            Assert.AreEqual(string.Empty, parsedLogLine.ColumnValues[0].Text);
+        }
+
+        [Test]
+        public void SplitLineRegexMatchesLine()
+        {
+            var columnizerConfig = new RegexColumnizerConfig
+            {
+                //We just need a regex that matches the line.
+                Expression = @"^(?'time'[\d]+)\s+(?'Message'.+)$",
+                Name = "Test regex"
+            };
+
+            var columnizer = new Regex1Columnizer();
+            columnizer.Init(columnizerConfig);
+            
+            var notMatchingLogLine = new TestLogLine(5, "5 test message");
+            
+            
+            var parsedLogLine = columnizer.SplitLine(Mock.Of<ILogLineColumnizerCallback>(), notMatchingLogLine);
+            
+            // verify that the expected number of columns are created
+            Assert.AreEqual(2, parsedLogLine.ColumnValues.Length);
+
+            //verify that the correct data is set to the correct columns
+            Assert.AreEqual("5", parsedLogLine.ColumnValues[0].Text);
+            Assert.AreEqual("test message", parsedLogLine.ColumnValues[1].Text);
+            
+        }
+        
+        private class TestLogLine : ILogLine
+        {
+            public TestLogLine(int lineNumber, string fullLine)
+            {
+                LineNumber = lineNumber;
+                FullLine = fullLine;
+            }
+
+            public string FullLine { get; set; }
+            public int LineNumber { get; set; }
+            public string Text { get; set; }
+        }
+    }
+    
+    
+}

--- a/src/RegexColumnizer.UnitTests/RegexColumnizerTests.cs
+++ b/src/RegexColumnizer.UnitTests/RegexColumnizerTests.cs
@@ -47,10 +47,9 @@ namespace RegexColumnizer.UnitTests
             var columnizer = new Regex1Columnizer();
             columnizer.Init(columnizerConfig);
             
-            var notMatchingLogLine = new TestLogLine(5, "5 test message");
-            
-            
-            var parsedLogLine = columnizer.SplitLine(Mock.Of<ILogLineColumnizerCallback>(), notMatchingLogLine);
+            var matchingLogLine = new TestLogLine(5, "5 test message");
+
+            var parsedLogLine = columnizer.SplitLine(Mock.Of<ILogLineColumnizerCallback>(), matchingLogLine);
             
             // verify that the expected number of columns are created
             Assert.AreEqual(2, parsedLogLine.ColumnValues.Length);

--- a/src/RegexColumnizer.UnitTests/packages.config
+++ b/src/RegexColumnizer.UnitTests/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="5.1.1" targetFramework="net472" />
-  <package id="Moq" version="4.18.4" targetFramework="net472" />
-  <package id="NUnit" version="3.5.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
-</packages>

--- a/src/RegexColumnizer.UnitTests/packages.config
+++ b/src/RegexColumnizer.UnitTests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="5.1.1" targetFramework="net472" />
+  <package id="Moq" version="4.18.4" targetFramework="net472" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+</packages>

--- a/src/RegexColumnizer/Properties/AssemblyInfo.cs
+++ b/src/RegexColumnizer/Properties/AssemblyInfo.cs
@@ -11,5 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+//Allow the unit tests to use internal methods to make tests easier to read/write and understand
+[assembly:InternalsVisibleTo("RegexColumnizer.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100619e9beea345a3bb5e15f55b29ddf40d96e9bb473ae58304fc63dfb3e9c94d8944bb7e45324ee0bef3e345dccba79b0bf64b85a128a7f261861899add639218ddaeb2acc6fcc746d6acb5bb212d375a0967756af192cfdb6cf0bff666a0fe535600abda860d3eafaff4ef1c9b5710181f72d996ca9c29ed64bae4a5fd916dea5")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b5a7dfa4-48a8-4616-8008-7441699ec946")]

--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -181,7 +181,7 @@ namespace RegexColumnizer
 
         protected abstract string GetNameInternal();
 
-        private void Init(RegexColumnizerConfig config)
+        internal void Init(RegexColumnizerConfig config)
         {
             Config = config;
 

--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -71,14 +71,15 @@ namespace RegexColumnizer
                         Parent = logLine,
                         FullValue = line.FullLine
                     };
+
                     
                     //Fill other columns with empty string to avoid null pointer exceptions in unexpected places
-                    for (int i = columns.Length - 2; i >= 0; i--)
+                    for (var i = 0; i < columns.Length - 1; i++)
                     {
                         logLine.ColumnValues[i] = new Column
                         {
                             Parent = logLine,
-                            FullValue = ""
+                            FullValue = string.Empty
                         };
                     }
                 }

--- a/src/RegexColumnizer/RegexColumnizer.cs
+++ b/src/RegexColumnizer/RegexColumnizer.cs
@@ -71,6 +71,16 @@ namespace RegexColumnizer
                         Parent = logLine,
                         FullValue = line.FullLine
                     };
+                    
+                    //Fill other columns with empty string to avoid null pointer exceptions in unexpected places
+                    for (int i = columns.Length - 2; i >= 0; i--)
+                    {
+                        logLine.ColumnValues[i] = new Column
+                        {
+                            Parent = logLine,
+                            FullValue = ""
+                        };
+                    }
                 }
             }
             else


### PR DESCRIPTION
I have added some code to the RegexColumnizer that will add columns with empty string when the line doesn't match the regex. 

The reason I made this alteration is to fix the following problem I have been having: If you use this RegexColumnizer to read logs that contain stack traces (lines that don't match the regex)  you get null columns for that line. This is visualized ok but will result in many error message pop-ups when searching in these columns making it hard to use this columnizer for these kind of logs. 

The added code aims to fix this problem by eliminating the null columns. This doesn't change the visualisation but fixed the search problem.