### PR TITLE
Making sure the appBounds in the Settings are within the current virt…

### DIFF
--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -281,6 +281,8 @@ namespace LogExpert.Config
                     settings.preferences.maximumFilterEntries = 30;
                 }
 
+                SetBoundsWithinVirtualScreen(settings);
+
                 ConvertSettings(settings);
 
                 return settings;
@@ -444,6 +446,17 @@ namespace LogExpert.Config
             return newList;
         }
 
+        // Checking if the appBounds values are outside the current virtual screen.
+        // If so, the appBounds values are set to 0.
+        private void SetBoundsWithinVirtualScreen(Settings settings)
+        {
+            var vs = SystemInformation.VirtualScreen;
+            if (vs.X + vs.Width < settings.appBounds.X + settings.appBounds.Width || 
+                vs.Y + vs.Height < settings.appBounds.Y + settings.appBounds.Height)
+            {
+                settings.appBounds = new Rectangle(); 
+            }
+        }
         #endregion
 
         protected void OnConfigChanged(SettingsFlags flags)


### PR DESCRIPTION
This fix looks at the stored appBounds information and make sure that the values are within the current virtual desktop bounds. It can happen that when you work on different virtual desktops the stored information is out of bounds making it impossible to locate or restore the view position. This is now checked and if the values are out of bounds the default windows bound setting is used.
The check is done in the ConfigManager just after the settings has been loaded. If the values in the appBounds are out of bounds for the current virtuel desktop the appBounds are set to 0 values. The views already checks for null and right value = 0 and skip setting the Bounds if so. This makes windows use the default values of the views and therefore showing on the primary screen.