### PR TITLE
Update LogStreamReaderBase.cs

### DIFF
--- a/src/LogExpert/Classes/Log/LogStreamReaderBase.cs
+++ b/src/LogExpert/Classes/Log/LogStreamReaderBase.cs
@@ -15,7 +15,7 @@ namespace LogExpert.Classes.Log
 
         ~LogStreamReaderBase()
         {
-            Dispose(true);
+            Dispose(false);
         }
 
         #endregion


### PR DESCRIPTION
Avoids NullReference on Finalizer on GC thread. A finalizer should always call Dispose with disposing set to false because some objects could already have been collected and set to null.

Dispose() (and so, with disposing set to true) is expected to be manually called in .net (all objects that implement IDisposable should be used together with `using` or Dispose(true) must be manually called by the developer, if it's feasible).
In any case, a finalizer is meant just as last resort (and in fact, in the general case, it is suggested not to implement it).

See https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/dispose-pattern#finalizable-types and the whole dispose-pattern page.

**Exception:**

_Object reference not set to an instance of an object.
NullReferenceException
   in LogExpert.Classes.Log.PositionAwareStreamReaderBase.Dispose(Boolean disposing)
   in LogExpert.Classes.Log.LogStreamReaderBase.Finalize()_

![immagine](https://github.com/user-attachments/assets/7dc319a8-7209-4dca-96cb-8d5f0e807052)
