### PR TITLE
Fix ArgumentException when FontName in setting file is not valid

### DIFF
--- a/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
+++ b/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
@@ -7179,7 +7179,20 @@ internal partial class LogWindow : DockContent, ILogPaintContextUI, ILogView, IL
     {
         if ((flags & SettingsFlags.GuiOrColors) == SettingsFlags.GuiOrColors)
         {
-            NormalFont = new Font(new FontFamily(fontName), fontSize);
+            Font NormalFont;
+
+            try
+            {
+                NormalFont = new Font(new FontFamily(fontName), fontSize);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.Warn($"Specified font '{fontName}' not found. Falling back to default. {ex.Message}");
+                // NOTE: Checking for invalid font name and falling back to default font might belong in LogExpert.Config.ConfigManager
+                NormalFont = new Font(FontFamily.GenericMonospace, fontSize);
+                Preferences.FontName = NormalFont.Name;
+            }
+            
             BoldFont = new Font(NormalFont, FontStyle.Bold);
             MonospacedFont = new Font("Courier New", Preferences.FontSize, FontStyle.Bold);
 

--- a/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
+++ b/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
@@ -7179,20 +7179,7 @@ internal partial class LogWindow : DockContent, ILogPaintContextUI, ILogView, IL
     {
         if ((flags & SettingsFlags.GuiOrColors) == SettingsFlags.GuiOrColors)
         {
-            Font NormalFont;
-
-            try
-            {
-                NormalFont = new Font(new FontFamily(fontName), fontSize);
-            }
-            catch (ArgumentException ex)
-            {
-                _logger.Warn($"Specified font '{fontName}' not found. Falling back to default. {ex.Message}");
-                // NOTE: Checking for invalid font name and falling back to default font might belong in LogExpert.Config.ConfigManager
-                NormalFont = new Font(FontFamily.GenericMonospace, fontSize);
-                Preferences.FontName = NormalFont.Name;
-            }
-            
+            NormalFont = new Font(new FontFamily(fontName), fontSize);
             BoldFont = new Font(NormalFont, FontStyle.Bold);
             MonospacedFont = new Font("Courier New", Preferences.FontSize, FontStyle.Bold);
 

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -206,13 +206,14 @@ public class ConfigManager : IConfigManager
 
             try
             {
-                var fontFamily = new FontFamily(settings.Preferences.FontName);
+                using var fontFamily = new FontFamily(settings.Preferences.FontName);
                 settings.Preferences.FontName = fontFamily.Name;
             }
             catch (ArgumentException ex)
             {
-                _logger.Warn($"Specified font '{settings.Preferences.FontName}' not found. Falling back to default: '{FontFamily.GenericMonospace.Name}'. {ex.Message}");
-                settings.Preferences.FontName = FontFamily.GenericMonospace.Name;
+                var genericMonospaceFont = FontFamily.GenericMonospace.Name;
+                _logger.Warn($"Specified font '{settings.Preferences.FontName}' not found. Falling back to default: '{genericMonospaceFont}'.");
+                settings.Preferences.FontName = genericMonospaceFont;
             }
 
             if (settings.Preferences.ShowTailColor == Color.Empty)

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -209,7 +209,7 @@ public class ConfigManager : IConfigManager
                 using var fontFamily = new FontFamily(settings.Preferences.FontName);
                 settings.Preferences.FontName = fontFamily.Name;
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException)
             {
                 var genericMonospaceFont = FontFamily.GenericMonospace.Name;
                 _logger.Warn($"Specified font '{settings.Preferences.FontName}' not found. Falling back to default: '{genericMonospaceFont}'.");

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -204,6 +204,17 @@ public class ConfigManager : IConfigManager
 
             settings.FileColors ??= [];
 
+            try
+            {
+                var fontFamily = new FontFamily(settings.Preferences.FontName);
+                settings.Preferences.FontName = fontFamily.Name;
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.Warn($"Specified font '{settings.Preferences.FontName}' not found. Falling back to default: '{FontFamily.GenericMonospace.Name}'. {ex.Message}");
+                settings.Preferences.FontName = FontFamily.GenericMonospace.Name;
+            }
+
             if (settings.Preferences.ShowTailColor == Color.Empty)
             {
                 settings.Preferences.ShowTailColor = Color.FromKnownColor(KnownColor.Blue);


### PR DESCRIPTION
Fixes LogExperts/LogExpert#468

The check for invalid font name and falling back to default font might be better placed in LogExpert.Config.ConfigManager but I've added it in LogWindow where the exception was thrown blocking application startup.